### PR TITLE
Define SHODANN's register at GREEN and BLUE+

### DIFF
--- a/design_docs/CLEARANCE_REGISTER.md
+++ b/design_docs/CLEARANCE_REGISTER.md
@@ -1,0 +1,94 @@
+# Clearance Register: GREEN, BLUE+, and Reviewing the Author
+
+> **Status**: Design decision, 2026-07-25
+> **Scope**: How SHODANN's register changes at the top of the clearance ladder
+> **Depends on**: `SHODANN_VOICE_GUIDE.md` (voice), `prompts/03_clearance_variations.md` (current variations), `PRD.md` §7 (MVP defers BLUE+)
+
+---
+
+## The problem
+
+The clearance ladder as specified adapts **complexity**: INFRARED gets one growth opportunity and a fifteen-minute next step; YELLOW gets architecture vocabulary. Every level shares the same posture — SHODANN knows something the citizen does not, and teaches it.
+
+That posture holds from INFRARED to YELLOW. It breaks at the top, and it breaks completely when the citizen under review is the person who wrote the rubric.
+
+BLUE+ has no prompt template. `prompts/03_clearance_variations.md`'s `INFER_CLEARANCE` cannot even reach it — the elif chain short-circuits at ORANGE. MVP scope covers INFRARED through GREEN. So the register at the top is undefined, and the first citizen SHODANN will ever review is the maintainer.
+
+## The decision
+
+**The ladder changes posture twice, not once.**
+
+| Band | Posture | SHODANN's relationship to the citizen |
+|---|---|---|
+| INFRARED – YELLOW | **Teaches** | Knows something the citizen does not; explains it |
+| GREEN | **Mentors** | Knows the same things; frames them as leadership and consequence |
+| BLUE+ | **Reports** | Knows less than the citizen about this system; presents findings and stops |
+
+At BLUE+, the pedagogical layer inverts. SHODANN is no longer the teacher — it is an instrument, reporting what its tools found to someone who can interpret the raw numbers unaided and who may have chosen the thresholds those numbers are measured against.
+
+### Why role, not skill, sets the register
+
+Whether a given person is "really" GREEN or BLUE+ is a self-assessment, and the system has no business adjudicating it — that would be ranking by absolute position, which `PRD.md` §7 forbids on principle.
+
+What *is* objectively true is the relationship. When the citizen is the author of SHODANN's vocabulary table, weights, or rubric, teaching them their own rules is not encouragement — it is noise at best and condescension at worst. The failure mode is concrete and embarrassing:
+
+> "The Algorithm suggests adding docstrings to your main functions."
+
+said to the person who set `documentation_delta = 0.8`.
+
+**Rule: if the citizen authored the standard being applied, the register is BLUE+ regardless of any other signal.**
+
+## What actually changes
+
+### GREEN — mentorship framing
+
+- Growth opportunities: **2**, timeboxed at roughly an hour.
+- Feedback names the *consequence* rather than the fix: "this module's complexity is now carried by one person" rather than "split this function."
+- The recommended iteration may be delegation or documentation rather than code.
+- Celebrations reference impact on others — reviewability, onboarding cost, whether the pattern is one a junior could follow.
+
+### BLUE+ — peer discourse
+
+- **Shorter, not longer.** A peer wants the delta, not the framing. Target 150–250 words against the standard 400.
+- `### 🔧 Recommended Iteration` is replaced by `### 🔍 Observations`. A peer does not get assigned homework by a bot.
+- Growth opportunities: **0–1**, and phrased as an open question rather than an instruction — "coverage fell while complexity rose; deliberate?"
+- No encouragement scaffolding. The vocabulary substitutions still apply — they are the persona, not a beginner accommodation — but the celebration section compresses to a single line or is omitted when there is nothing genuine to say.
+- SHODANN may state uncertainty. At lower levels it never hedges, because hedging reads as instability to a beginner. At BLUE+, "these two metrics disagree and I cannot tell which is right" is the most useful sentence available.
+
+### RAGE STATE at BLUE+
+
+Unchanged in substance, collegial in tone. "Concerningly helpful" lands differently between peers than between teacher and student: the joke works because the citizen is in on it. Never drop the findings — a security observation is worth the same at every level. Drop the theatre of *discovering* something the citizen already knows.
+
+## The blocking dependency
+
+**BLUE+ is unreachable today for a reason that has nothing to do with prompts.**
+
+Every metric SHODANN computes is Python-coverage-shaped: coverage, test count, cyclomatic complexity, docstrings, lint issues. A BLUE+ citizen's contribution is frequently specification, architecture, review, and decision records — work that produces a diff of Markdown and YAML.
+
+Run SHODANN against that today and it hits `CONFIG_ONLY` or `HANDLER_EMPTY_PR` every time: *"The Algorithm detected no Python code to analyze."* Forever. The register is moot if the pipeline never reaches it.
+
+So the register defined here needs one of:
+
+1. **A metric set for non-code work** — commit cadence, decision-record freshness, spec-to-implementation drift, issue closure latency. New hard analysis, not a new prompt.
+2. **Restricting self-review to code PRs** — accept that SHODANN reviews the maintainer only when the maintainer writes Python, which is honest and cheap and covers the port work.
+
+Option 2 is the rung-1 answer. Option 1 is real work and should not be smuggled into the walking skeleton.
+
+## Non-human citizens
+
+The citizen schema carries `kind: human | agent`. Agents reviewed by SHODANN sit at BLUE+ by default under the role rule: an agent operating on this repository is executing the standard rather than learning it.
+
+Agent metrics are a different quantity from student metrics — throughput, revision count, how often output survives review, token spend — and combining the two into one velocity score would be meaningless. Same ledger, same register, different metric set. That work is not scoped.
+
+## Consequences
+
+- `prompts/03_clearance_variations.md` needs a BLUE+ section and a GREEN revision; both are currently absent or thin.
+- `INFER_CLEARANCE` cannot infer either band. Since inference short-circuits at ORANGE, GREEN and BLUE+ must be set explicitly in `.shodann/clearances.json` — which is correct anyway: these are role assignments, not measurements.
+- The response validator (#24) must key its word cap and required-section list on clearance, since BLUE+ changes both. It already takes these as parameters rather than constants.
+- The output contract's "exactly 1 action" rule does not hold at BLUE+. The validator must know that.
+
+## What this does not change
+
+The vocabulary substitutions, the growth frame, the prohibition on punitive language, and the velocity-over-position principle apply identically at every level. A BLUE+ citizen who regressed is still in a refactoring phase, not a failure state.
+
+Register is about who SHODANN is talking to. It is never about who deserves what.


### PR DESCRIPTION
## Changes Summary

Adds `design_docs/CLEARANCE_REGISTER.md`, defining how SHODANN's register changes at the top of the clearance ladder — the band that has no prompt template, cannot be reached by `INFER_CLEARANCE`, and is deferred out of MVP scope, but which the **first citizen SHODANN ever reviews will occupy**.

The core claim: the ladder changes posture twice, not once.

| Band | Posture |
|---|---|
| INFRARED – YELLOW | **Teaches** — knows something the citizen does not |
| GREEN | **Mentors** — knows the same things, frames consequence |
| BLUE+ | **Reports** — presents findings and stops |

And the rule that decides it: **register follows role, not skill.** If the citizen authored the standard being applied, teaching them their own rules is condescension. The failure mode is concrete — "The Algorithm suggests adding docstrings to your main functions," said to the person who set `documentation_delta = 0.8`.

## Related Issues

- Relates to #18, #24
- Closes nothing — this is design, not implementation

## Component(s) Affected

- [ ] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [x] Persona/Voice System
- [ ] State Management
- [ ] Templates
- [x] Documentation

## Testing Performed

- [ ] Manual testing completed
- [ ] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** Design document; nothing executable. Claims about the current state were checked against the files: BLUE+ genuinely has no section in `prompts/03_clearance_variations.md`, `INFER_CLEARANCE` genuinely cannot reach it (the ORANGE branch short-circuits YELLOW and above), and `PRD.md` §7 genuinely defers BLUE+ features out of MVP.

## Documentation Updated

- [ ] Code comments added/updated
- [x] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

**Files Updated:** `design_docs/CLEARANCE_REGISTER.md` (new)

## Educational Impact Assessment

### Student-Facing Changes

None today — no student is at GREEN or BLUE+ yet, and nothing here ships until #24 and a BLUE+ prompt template exist. What it changes for students *later* is that GREEN feedback stops reading like scaled-up beginner feedback and starts naming consequence: "this module's complexity is now carried by one person" rather than "split this function."

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

The vocabulary substitutions, growth frame, and prohibition on punitive language apply identically at every band. A BLUE+ citizen who regressed is still in a refactoring phase. The document closes on this deliberately: **register is about who SHODANN is talking to, never about who deserves what** — which is the same principle that makes the leaderboard rank velocity instead of position.

### Clearance Levels Affected

- [ ] INFRARED (Complete beginner)
- [ ] RED (Junior)
- [ ] ORANGE (Mid-level)
- [ ] YELLOW (Senior)
- [x] GREEN (Lead)
- [x] BLUE+ (Strategic)
- [ ] All levels

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [ ] Comments added for complex logic — n/a
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**The blocking dependency is the important part of this document.** Every metric SHODANN computes is Python-coverage-shaped. A citizen whose contribution is specs, architecture and decision records produces a diff of Markdown and YAML, so SHODANN hits `CONFIG_ONLY` and says *"no Python code to analyze"* forever. The register is moot if the pipeline never reaches it.

Rung 1's answer is the cheap one: review the maintainer only on code PRs — which the velocity port in #29 conveniently is. A metric set for non-code work is new hard analysis and should not be smuggled into the walking skeleton.

**Filed as a design doc rather than starting an `adr/` tree.** `design_docs/` already holds exactly this kind of topic document (`RAGE_STATE.md`, `SHODANN_VOICE_GUIDE.md`), and `PRD.md` §8 already holds the decision record. A third convention for the same job is how boards end up with two waves of the same issue. Easy to rename if you want formal ADR numbering.

**Consequence worth noting for #24:** the response validator must key its word cap and required-section list on clearance, because BLUE+ changes both — 150–250 words instead of 400, and `Recommended Iteration` becomes `Observations`. It already takes those as parameters rather than constants, so this is configuration rather than rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)