### PR TITLE
Render the layered prompts with Jinja2

### DIFF
--- a/prompts/01_base_shodann_prompt.md
+++ b/prompts/01_base_shodann_prompt.md
@@ -18,6 +18,11 @@ This prompt follows the 4-layer architecture:
 
 ## Full Prompt Template
 
+Everything between the TEMPLATE markers below is what the renderer extracts and
+sends to the model. Text outside them - including the variable reference table
+further down - is documentation for humans and is never rendered.
+
+<!-- TEMPLATE:BEGIN -->
 ```
 # =============================================================================
 # LAYER 0: SHODANN IDENTITY
@@ -247,6 +252,7 @@ Do NOT use emojis within paragraph text except for:
 - [UPWARD CHART EMOJI] when noting positive delta
 - [DOWNWARD CHART EMOJI] when noting negative delta (rare, reframe as opportunity)
 ```
+<!-- TEMPLATE:END -->
 
 ---
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -22,6 +22,7 @@ enforces the growth-positive vocabulary mandated by The Algorithm.
 | `03_clearance_variations.md` | Level-specific guidance | Based on citizen clearance |
 | `04_first_submission_prompt.md` | Onboarding mode | First PR from citizen |
 | `05_edge_case_handlers.md` | Unusual submissions | Empty, failing, massive PRs |
+| `06_assembled_example.md` | Worked end-to-end example | Reference only, never rendered |
 
 ---
 
@@ -186,22 +187,41 @@ EDGE_CASE_HANDLER: enum of handler type
 
 ## Testing Prompts Locally
 
-To test prompt construction without running the full workflow:
+Rendering is done by `shodann.prompts`, offline, with no API key:
 
 ```bash
-# Create test variables
-export CITIZEN_USERNAME="test_citizen"
-export CLEARANCE_NAME="RED"
-export CURRENT_COVERAGE="45"
-export PREV_COVERAGE="30"
-# ... etc
-
-# Use envsubst or similar to inject variables
-envsubst < 01_base_shodann_prompt.md > test_prompt.txt
-
-# Send to Gemini API for testing
-# (requires GEMINI_API_KEY)
+python -c "from shodann.prompts import render_prompt, build_context; print(render_prompt(...))"
 ```
+
+See `tests/test_prompts.py` for a worked context. The test suite renders the
+base template on every run and asserts nothing is left unresolved.
+
+### Why not envsubst
+
+An earlier version of this file suggested `envsubst < 01_base_shodann_prompt.md`.
+That cannot work, for three separate reasons, and it is worth knowing all three
+before reaching for a simpler tool:
+
+1. **`envsubst` expands `$VAR`, not `{{ VAR }}`.** It would substitute nothing
+   at all and emit the template unchanged.
+2. **These files are documents, not templates.** The prompt lives inside a
+   fenced block, and the same file carries a variable-reference table that
+   mentions every placeholder as documentation. Whole-file substitution would
+   rewrite the documentation too. The renderable region is delimited by
+   `<!-- TEMPLATE:BEGIN -->` / `<!-- TEMPLATE:END -->` markers.
+3. **Templates `02`, `04` and `05` contain control flow** — `{{ IF X }}`,
+   `{{ FOR EACH x IN y }}`, `{{ TESTS_PASSED + TESTS_FAILED }}` — which no
+   substitution tool can interpret. They need converting to real Jinja
+   (`{% if X %}`, `{% for x in y %}`) before they can be rendered at all. The
+   renderer detects the ad-hoc syntax and reports the file and line rather than
+   failing with a parser trace.
+
+### Markers are required
+
+A template with no `TEMPLATE:BEGIN` / `TEMPLATE:END` pair raises rather than
+guessing, because guessing means sending a variable-reference table to the
+model. Only `01` carries markers today; the rest are added as each template
+comes into scope.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "shodann"
 version = "0.1.0"
 description = "The Algorithm's benevolent educational oversight system"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = ["jinja2>=3.1"]
 
 [project.optional-dependencies]
 # ruff is pinned exactly, pytest is not. ruff's C901 output feeds the velocity

--- a/src/shodann/prompts.py
+++ b/src/shodann/prompts.py
@@ -1,0 +1,253 @@
+"""Assemble the prompt sent to the model.
+
+The files in ``prompts/`` are documents *about* prompts: the prompt itself sits
+inside a fenced block, and the same file carries a variable-reference table
+that mentions every placeholder as documentation. Rendering a whole file would
+happily substitute the documentation too, so the renderable region is delimited
+explicitly:
+
+    <!-- TEMPLATE:BEGIN -->
+    ...the actual prompt...
+    <!-- TEMPLATE:END -->
+
+Templates use ``{{ UPPER_SNAKE }}`` with inner spaces, which is already valid
+Jinja, so variable substitution needed no rewriting. What did need handling:
+
+* **Missing variables must be loud.** ``StrictUndefined`` turns a forgotten
+  binding into an exception at render time rather than a literal ``{{ FOO }}``
+  arriving in a student's feedback.
+* **Bracketed emoji names.** The templates write ``[ROCKET EMOJI]`` where the
+  output contract requires an actual emoji. Left alone, the model copies the
+  bracket text into the comment.
+* **Author annotations.** HTML comments inside the template are notes to
+  whoever maintains it, not instructions for the model. They are stripped.
+* **Pseudo-control-flow.** Templates 02, 04 and 05 contain ``{{ IF X }}`` and
+  ``{{ FOR EACH x IN y }}``, which are not Jinja and raise a syntax error that
+  says nothing useful. Those are detected up front and reported by file and
+  line, with the conversion that would fix them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from jinja2 import Environment, StrictUndefined
+
+from .state import CitizenRecord, clearance_name
+from .velocity import CodeMetrics, VelocityResult
+
+__all__ = [
+    "BASE_TEMPLATE",
+    "PROMPTS_DIR",
+    "UnsupportedTemplateSyntax",
+    "build_context",
+    "describe_history",
+    "extract_template",
+    "find_pseudo_syntax",
+    "render_prompt",
+    "render_template_text",
+]
+
+PROMPTS_DIR = Path("prompts")
+BASE_TEMPLATE = "01_base_shodann_prompt.md"
+
+TEMPLATE_BEGIN = "<!-- TEMPLATE:BEGIN -->"
+TEMPLATE_END = "<!-- TEMPLATE:END -->"
+
+EMOJI = {
+    "ROBOT EMOJI": "\U0001f916",
+    "ROCKET EMOJI": "\U0001f680",
+    "CHECK EMOJI": "✅",
+    "CHART EMOJI": "\U0001f4c8",
+    "WRENCH EMOJI": "\U0001f527",
+    "LOCK EMOJI": "\U0001f512",
+    "UPWARD CHART EMOJI": "\U0001f4c8",
+    "DOWNWARD CHART EMOJI": "\U0001f4c9",
+}
+
+_EMOJI_PATTERN = re.compile(r"\[([A-Z ]+EMOJI)\]")
+_HTML_COMMENT = re.compile(r"[ \t]*<!--.*?-->[ \t]*\n?", re.DOTALL)
+
+# {{ IF x }}, {{ ELSE }}, {{ ENDIF }}, {{ END IF }}, {{ FOR EACH x IN y }},
+# {{ END FOR }}, {{ EXAMPLE }}, {{ END EXAMPLES }} - none of it is Jinja.
+_PSEUDO_SYNTAX = re.compile(r"\{\{\s*(IF|ELSE|ENDIF|END\s+\w+|FOR\s+EACH|EXAMPLE)\b[^}]*\}\}")
+
+
+class UnsupportedTemplateSyntax(ValueError):
+    """A template carries control flow the renderer cannot interpret."""
+
+
+def find_pseudo_syntax(text: str) -> list[tuple[int, str]]:
+    """Locate ad-hoc control flow, as ``(line number, matched text)`` pairs."""
+    found = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        found.extend((number, match.group(0)) for match in _PSEUDO_SYNTAX.finditer(line))
+    return found
+
+
+def extract_template(path: Path | str) -> str:
+    """Pull the renderable region out of a prompt document.
+
+    Raises if the markers are missing rather than guessing, because guessing
+    would silently send a variable-reference table to the model.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+
+    if TEMPLATE_BEGIN not in text or TEMPLATE_END not in text:
+        raise UnsupportedTemplateSyntax(
+            f"{path}: no {TEMPLATE_BEGIN} / {TEMPLATE_END} markers. "
+            "Wrap the prompt body in them so the renderer knows what is template "
+            "and what is documentation."
+        )
+
+    body = text.split(TEMPLATE_BEGIN, 1)[1].split(TEMPLATE_END, 1)[0]
+
+    # The markers sit outside the fence that makes the prompt readable on
+    # GitHub; the fence itself is not part of the prompt.
+    lines = body.strip().splitlines()
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].startswith("```"):
+        lines = lines[:-1]
+    return "\n".join(lines).strip() + "\n"
+
+
+def _resolve_emoji(text: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        return EMOJI.get(match.group(1), match.group(0))
+
+    return _EMOJI_PATTERN.sub(replace, text)
+
+
+def render_template_text(
+    template_text: str,
+    context: dict,
+    *,
+    source: str = "<string>",
+    strip_comments: bool = True,
+) -> str:
+    """Render already-extracted template text.
+
+    Split out from :func:`render_prompt` so prompt assembly can be unit tested
+    without touching the filesystem.
+    """
+    pseudo = find_pseudo_syntax(template_text)
+    if pseudo:
+        detail = ", ".join(f"line {number}: {text}" for number, text in pseudo[:5])
+        raise UnsupportedTemplateSyntax(
+            f"{source}: contains control flow the renderer cannot interpret ({detail}). "
+            "Convert it to Jinja - {{ IF X }} becomes {% if X %}, "
+            "{{ FOR EACH x IN y }} becomes {% for x in y %} - or render a template "
+            "that does not use it."
+        )
+
+    environment = Environment(
+        undefined=StrictUndefined,
+        autoescape=False,  # noqa: S701 - markdown for an LLM, never HTML for a browser
+        keep_trailing_newline=True,
+    )
+    rendered = environment.from_string(template_text).render(**context)
+
+    if strip_comments:
+        rendered = _HTML_COMMENT.sub("", rendered)
+    return _resolve_emoji(rendered)
+
+
+def build_context(
+    result: VelocityResult,
+    record: CitizenRecord,
+    *,
+    pr_title: str,
+    files_changed: int,
+    lines_added: int,
+    lines_removed: int,
+    current_week: str = "",
+    syntax_report: str = "No syntax analysis performed.",
+    style_report: str = "No style analysis performed.",
+    test_report: str = "No tests executed.",
+    tests_passed: int = 0,
+    tests_failed: int = 0,
+    style_issue_count: int = 0,
+    clearance_instructions: str = "",
+    security_section: str = "",
+    rage_section: str = "",
+    mode_statement: str = "NORMAL (Growth Celebration)",
+) -> dict:
+    """Map domain objects onto the template's variables.
+
+    Every placeholder in the base template gets a value here - a missing one
+    would raise at render time, which is the point, but it should never get
+    that far in production.
+    """
+    previous = record.last_metrics or CodeMetrics.baseline()
+    current = result.deltas
+
+    return {
+        "MODE_STATEMENT": mode_statement,
+        "CITIZEN_USERNAME": record.citizen,
+        "CLEARANCE_NAME": clearance_name(record.clearance_level),
+        "CLEARANCE_NUMBER": record.clearance_level,
+        "CURRENT_WEEK": current_week,
+        "PR_COUNT": record.pr_count,
+        "PREV_COVERAGE": round(previous.coverage, 1),
+        "PREV_STREAK": record.iteration_streak,
+        "PR_TITLE": pr_title,
+        "FILES_CHANGED": files_changed,
+        "LINES_ADDED": lines_added,
+        "LINES_REMOVED": lines_removed,
+        "ITERATION_COUNT": result.iterations,
+        "HISTORY_NARRATIVE": describe_history(record, result),
+        "SYNTAX_REPORT": syntax_report,
+        "SYNTAX_ERRORS": 0,
+        "STYLE_REPORT": style_report,
+        "STYLE_ISSUE_COUNT": style_issue_count,
+        "TEST_REPORT": test_report,
+        "TESTS_PASSED": tests_passed,
+        "TESTS_FAILED": tests_failed,
+        "CURRENT_COVERAGE": round(previous.coverage + current.coverage, 1),
+        "PREV_COMPLEXITY": previous.complexity,
+        "CURRENT_COMPLEXITY": previous.complexity + current.complexity,
+        "COMPLEXITY_DELTA": current.complexity,
+        "COVERAGE_DELTA": round(current.coverage, 1),
+        "VELOCITY_SCORE": result.score,
+        "VELOCITY_ASSESSMENT": result.assessment,
+        "SECURITY_SECTION": security_section,
+        "CLEARANCE_INSTRUCTIONS": clearance_instructions,
+        "RAGE_SECTION_IF_ACTIVE": rage_section,
+    }
+
+
+def describe_history(record: CitizenRecord, result: VelocityResult) -> str:
+    """One or two sentences of context for the model. Facts only, no framing."""
+    if result.is_first_submission or record.pr_count <= 1:
+        return (
+            "This is the citizen's first submission. No previous metrics exist, "
+            "so every delta is measured against a zero baseline."
+        )
+    return (
+        f"Submission number {record.pr_count}. Velocity trend: "
+        f"{record.velocity_trend.upper()}. Iteration streak: {record.iteration_streak}."
+    )
+
+
+def render_prompt(
+    context: dict,
+    *,
+    template: str = BASE_TEMPLATE,
+    prompts_dir: Path | str = PROMPTS_DIR,
+    strip_comments: bool = True,
+) -> str:
+    """Render one prompt document against ``context``.
+
+    Rung 1 renders the base template only. Mode selection, clearance
+    calibration, RAGE STATE and the edge-case handlers each replace or extend
+    this and are not wired up yet.
+    """
+    path = Path(prompts_dir) / template
+    return render_template_text(
+        extract_template(path),
+        context,
+        source=str(path),
+        strip_comments=strip_comments,
+    )

--- a/src/shodann/state.py
+++ b/src/shodann/state.py
@@ -42,6 +42,21 @@ TREND_STABLE = "stable"
 KIND_HUMAN = "human"
 KIND_AGENT = "agent"
 
+CLEARANCE_NAMES = {
+    1: "INFRARED",
+    2: "RED",
+    3: "ORANGE",
+    4: "YELLOW",
+    5: "GREEN",
+    6: "BLUE+",
+}
+"""Clearance ladder. Anything above 6 is BLUE+; see design_docs/CLEARANCE_REGISTER.md."""
+
+
+def clearance_name(level: int) -> str:
+    """Name for a clearance level, saturating at BLUE+ rather than failing."""
+    return CLEARANCE_NAMES.get(max(1, min(level, 6)), "RED")
+
 VISIBILITY_NAMED = "named"
 VISIBILITY_ANONYMOUS = "anonymous"
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,161 @@
+"""Prompt assembly: extraction, strict binding, and the syntax we cannot render."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, StrictUndefined, meta
+from jinja2.exceptions import UndefinedError
+
+from shodann.prompts import (
+    BASE_TEMPLATE,
+    UnsupportedTemplateSyntax,
+    build_context,
+    extract_template,
+    find_pseudo_syntax,
+    render_prompt,
+    render_template_text,
+)
+from shodann.state import CitizenRecord
+from shodann.velocity import CodeMetrics, calculate_velocity
+
+PROMPTS = Path(__file__).parent.parent / "prompts"
+
+
+def sample_context() -> dict:
+    record = CitizenRecord(citizen="octocat", clearance_level=3, pr_count=4, iteration_streak=2)
+    record.last_metrics = CodeMetrics(coverage=45.0, test_count=6, complexity=11)
+    result = calculate_velocity(
+        CodeMetrics(coverage=52.0, test_count=9, complexity=14),
+        record.last_metrics,
+        3,
+    )
+    return build_context(
+        result,
+        record,
+        pr_title="Add inventory tests",
+        files_changed=4,
+        lines_added=120,
+        lines_removed=18,
+        current_week="6",
+    )
+
+
+# --- extraction -----------------------------------------------------------
+
+
+def test_extraction_excludes_the_documentation() -> None:
+    """The file's own variable table mentions every placeholder as prose."""
+    body = extract_template(PROMPTS / BASE_TEMPLATE)
+
+    assert "LAYER 0: SHODANN IDENTITY" in body
+    assert "Variable Injection Reference" not in body
+    assert "Implementation Notes" not in body
+    assert "`github.event.pull_request.user.login`" not in body
+
+
+def test_extraction_drops_the_outer_fence_but_keeps_inner_ones() -> None:
+    """Inner fences delimit tool reports and are part of the prompt."""
+    body = extract_template(PROMPTS / BASE_TEMPLATE)
+
+    assert not body.lstrip().startswith("```")
+    assert "```\n{{ SYNTAX_REPORT }}\n```" in body
+
+
+def test_missing_markers_is_an_error_not_a_guess(tmp_path) -> None:
+    unmarked = tmp_path / "unmarked.md"
+    unmarked.write_text("# Docs\n\nSome prose with {{ CITIZEN_USERNAME }}.\n", encoding="utf-8")
+
+    with pytest.raises(UnsupportedTemplateSyntax, match="TEMPLATE:BEGIN"):
+        extract_template(unmarked)
+
+
+# --- rendering ------------------------------------------------------------
+
+
+def test_base_template_renders_with_nothing_left_unresolved() -> None:
+    rendered = render_prompt(sample_context(), prompts_dir=PROMPTS)
+
+    assert "{{" not in rendered
+    assert "}}" not in rendered
+    assert "[ROBOT EMOJI]" not in rendered
+    assert "EMOJI]" not in rendered
+
+
+def test_build_context_supplies_every_variable_the_template_declares() -> None:
+    """Enumerate the template's variables rather than trusting a hand-written list."""
+    source = extract_template(PROMPTS / BASE_TEMPLATE)
+    environment = Environment(undefined=StrictUndefined, autoescape=False)  # noqa: S701
+    declared = meta.find_undeclared_variables(environment.parse(source))
+
+    missing = declared - set(sample_context())
+    assert not missing, f"build_context does not supply: {sorted(missing)}"
+
+
+def test_bracketed_emoji_names_become_emoji() -> None:
+    rendered = render_prompt(sample_context(), prompts_dir=PROMPTS)
+
+    assert "\U0001f916" in rendered, "robot, for the analysis header"
+    assert "\U0001f680" in rendered, "rocket, for the velocity report"
+    assert "\U0001f512" in rendered, "lock, for security observations"
+
+
+def test_author_annotations_do_not_reach_the_model() -> None:
+    rendered = render_prompt(sample_context(), prompts_dir=PROMPTS)
+
+    assert "<!--" not in rendered
+    assert "Injected as:" not in rendered
+
+
+def test_annotations_can_be_kept_for_inspection() -> None:
+    rendered = render_prompt(sample_context(), prompts_dir=PROMPTS, strip_comments=False)
+    assert "<!--" in rendered
+
+
+def test_a_forgotten_variable_raises_instead_of_leaking(tmp_path) -> None:
+    """A literal {{ FOO }} in a student's feedback is the failure this prevents."""
+    with pytest.raises(UndefinedError):
+        render_template_text("Citizen: {{ CITIZEN_USERNAME }} at {{ NOT_PROVIDED }}", {
+            "CITIZEN_USERNAME": "octocat"
+        })
+
+
+def test_rendered_prompt_carries_the_facts_it_was_given() -> None:
+    rendered = render_prompt(sample_context(), prompts_dir=PROMPTS)
+
+    assert "@octocat" in rendered
+    assert "ORANGE" in rendered
+    assert "Add inventory tests" in rendered
+    assert "52.0%" in rendered
+
+
+# --- the syntax we cannot render -----------------------------------------
+
+
+def test_pseudo_control_flow_is_found_with_line_numbers() -> None:
+    found = find_pseudo_syntax("a\n{{ IF X }}\nb\n{{ ENDIF }}\n")
+    assert [number for number, _ in found] == [2, 4]
+
+
+@pytest.mark.parametrize(
+    "template",
+    ["02_rage_state_addon.md", "04_first_submission_prompt.md", "05_edge_case_handlers.md"],
+)
+def test_templates_with_control_flow_fail_with_a_useful_message(template: str) -> None:
+    """These are out of scope for rung 1; the error must say why, not raise a Jinja trace."""
+    path = PROMPTS / template
+    if "TEMPLATE:BEGIN" not in path.read_text(encoding="utf-8"):
+        pytest.skip(f"{template} has no template markers yet")
+
+    with pytest.raises(UnsupportedTemplateSyntax, match="control flow"):
+        render_prompt(sample_context(), template=template, prompts_dir=PROMPTS)
+
+
+def test_the_error_names_the_conversion() -> None:
+    with pytest.raises(UnsupportedTemplateSyntax) as caught:
+        render_template_text("{{ IF FILES_CHANGED == 0 }}x{{ ENDIF }}", {})
+
+    message = str(caught.value)
+    assert "{% if" in message
+    assert "line 1" in message

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -86,6 +86,7 @@ def test_base_template_renders_with_nothing_left_unresolved() -> None:
 def test_build_context_supplies_every_variable_the_template_declares() -> None:
     """Enumerate the template's variables rather than trusting a hand-written list."""
     source = extract_template(PROMPTS / BASE_TEMPLATE)
+    # noqa: S701 - parse-only, and markdown for an LLM is never HTML for a browser
     environment = Environment(undefined=StrictUndefined, autoescape=False)  # noqa: S701
     declared = meta.find_undeclared_variables(environment.parse(source))
 


### PR DESCRIPTION
## Changes Summary

Replaces the hand-rolled substitution the docs described with Jinja2 — and fixes a structural problem the issue did not anticipate.

**The files in `prompts/` are documents *about* prompts.** The prompt itself sits inside a fenced code block, and the same file carries a "Variable Injection Reference" table that mentions every placeholder as documentation. Rendering the whole file would have cheerfully substituted the documentation too, and sent a variable-reference table to the model.

The renderable region is now delimited explicitly:

```
<!-- TEMPLATE:BEGIN -->
...the actual prompt...
<!-- TEMPLATE:END -->
```

A file without markers raises rather than guessing. Only `01` carries them today; the rest get them as each template comes into scope.

### Four things that would each have reached a student

| Problem | Handling |
|---|---|
| A forgotten binding renders as a literal `{{ FOO }}` in someone's feedback | `StrictUndefined` — raises at render time |
| Templates write `[ROCKET EMOJI]` where the output contract requires an emoji; the model copies the bracket text through | Resolved to real emoji during render |
| HTML comments are notes to the template's maintainer, not instructions for the model | Stripped before sending (`strip_comments=False` to inspect) |
| Templates `02`, `04`, `05` contain `{{ IF X }}` and `{{ FOR EACH x IN y }}`, which raise an unhelpful Jinja parser error | Detected up front, reported by file and line, with the `{% if %}` conversion that would fix it |

`{{ UPPER_SNAKE }}` with inner spaces is already valid Jinja, so variable substitution itself needed no rewriting.

### Docs

`prompts/README.md` documented `envsubst < 01_base_shodann_prompt.md`. That could never have worked, for three separate reasons, all now written down so nobody reaches for a simpler tool again: envsubst expands `$VAR` not `{{ VAR }}`; these are documents rather than templates; and three of the five carry control flow no substitution tool can interpret. Also added `06` to the template index, which was missing.

## Related Issues

- Closes #23
- Relates to #18, #24, #25

## Component(s) Affected

- [ ] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [x] Persona/Voice System
- [ ] State Management
- [x] Templates
- [x] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 64 passed, 3 skipped, ruff clean. Gated by `oracle-warden` before opening: **GATE PASS**, all 8 checks, run on haiku.

The strongest test enumerates the template's variables with `jinja2.meta.find_undeclared_variables` and asserts `build_context` supplies every one — rather than trusting a hand-written list to stay in sync with the template. Others cover extraction excluding the documentation region, inner fences surviving (they delimit tool reports and are part of the prompt), emoji resolution, comment stripping, a missing binding raising rather than leaking, and the pseudo-syntax error naming both the line and the conversion.

**The 3 skips are honest:** the control-flow tests for `02`, `04` and `05` skip because those templates have no `TEMPLATE:BEGIN` markers yet. The error path itself is covered directly against a string, so behaviour is tested; what is skipped is the file-level assertion that cannot run until those templates come into scope. The warden reported the skip count and reason rather than letting it pass unnoticed.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [x] User-facing documentation updated
- [ ] No documentation changes needed

**Files Updated:** `prompts/README.md` (testing section rewritten, `06` indexed), `prompts/01_base_shodann_prompt.md` (markers)

## Educational Impact Assessment

### Student-Facing Changes

Nothing ships until #25, but this is the layer that decides what a student actually reads, and three of the four fixes above are cases where the failure would have been *visible to them*: a literal `{{ CITIZEN_USERNAME }}` in their feedback, a section header reading `[ROCKET EMOJI]`, or the template's own author annotations quoted back at them.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

The rendered prompt carries the vocabulary substitution table and the growth-mindset requirements through to the model unchanged — those live in LAYER 3 of the template and are now provably present in the output rather than assumed.

### Clearance Levels Affected

- [ ] INFRARED (Complete beginner)
- [ ] RED (Junior)
- [ ] ORANGE (Mid-level)
- [ ] YELLOW (Senior)
- [ ] GREEN (Lead)
- [ ] BLUE+ (Strategic)
- [x] All levels — once #25 wires it up
- [ ] Not student-facing

`{{ CLEARANCE_INSTRUCTIONS }}` is bound but empty: clearance calibration is `03`'s job and is not wired up. The context builder resolves the clearance *name* from the ladder (`INFRARED` … `BLUE+`), saturating rather than failing on an out-of-range level.

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**`jinja2>=3.1` is now a runtime dependency** — the first one this project has. Unpinned deliberately, following the rule established in #31: only tools whose output feeds the velocity score get an exact pin, because only those can move a citizen's baseline. Jinja renders text; it measures nothing.

**One judgement call:** `build_context` maps domain objects onto the template's 31 variables and lives in `prompts.py`. It is slightly beyond what #23 asked for — the issue only required rendering from a fixture dict — but without it #25 would have to hand-assemble 31 keys, and the "supplies every declared variable" test would have had nothing real to assert against.

**Warden feedback applied:** its report noted that the `# noqa: S701` in the test lacked the justification comment its counterpart in `prompts.py` carries. Fixed rather than argued with — a suppression without a stated reason is exactly what that check exists to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
