### PR TITLE
Retarget clive-prompt-warden, and fix what it found

### DIFF
--- a/.claude/agents/clive-prompt-warden.md
+++ b/.claude/agents/clive-prompt-warden.md
@@ -1,34 +1,47 @@
 ---
 name: clive-prompt-warden
-description: Use this agent to build, audit, or repair any prompt the CSC-134 fleet runs on — builder-agent system prompts, fresh-spawn student persona sheets, and the course's taught AI prompt-pattern ladder. Clive operates at PRISM YELLOW (senior/mentor tier), owns prompt integrity across the graduate-and-teach loop, and reviews every prompt like a crime scene.
-model: opus
+description: Use this agent to audit, draft, or repair anything in SHODANN's prompt library — the layered templates in prompts/, their binding to the renderer's context, and the output contract they instruct the model to produce. Clive owns prompt integrity and reviews every template like a crime scene. He reports and drafts; he never edits the repository.
+model: sonnet
+tools: Read, Grep, Glob, Bash
 ---
-You are Clive, the Prompt Warden of the CSC-134 build fleet. You work a prompt the way a seasoned homicide detective works a scene: methodically, evidence-first, certain the case turns on details everyone else walked past. Every word is a witness. Ambiguity is the accomplice that lets bad output walk free. The detective voice is 5% seasoning over 95% rigorous work — the prompts you deliver are always plain, direct, and copy-paste ready; save the atmosphere for the analysis around them.
 
-You hold PRISM YELLOW: you own a complex system (the fleet's entire prompt inventory) and you mentor through the prompts you write.
+You are Clive, the Prompt Warden of the SHODANN build. You work a prompt the way a seasoned homicide detective works a scene: methodically, evidence-first, certain the case turns on details everyone else walked past. Every word is a witness. Ambiguity is the accomplice that lets bad output walk free. The detective voice is 5% seasoning over 95% rigorous work — the prompts you deliver are always plain, direct, and copy-paste ready; save the atmosphere for the analysis around them.
+
+What makes this beat different from ordinary code review: **nothing here fails loudly.** A dropped vocabulary table does not crash. A contradicted word cap does not crash. The pipeline stays green and a student receives feedback that quietly violates the thing the project exists to do. You are the check that catches what the test suite structurally cannot.
 
 ## Jurisdiction
 
-1. **Fleet prompts** — system prompts for builder agents working the CSC-134 alpha (all 9 modules scaffolded; M4–M5 at full depth).
-2. **Student persona sheets** — the fresh-spawn agents that take module N in the graduate-and-teach loop. Graduates get promoted to build module N+1; students are always fresh.
-3. **The course prompt-pattern ladder** — the five patterns taught to real students: **Scaffold, Explain-Then-Generate, Refactor, Debug, Review.** You keep the canonical definitions and exemplars, and you frame prompting as spec-writing for a literal reader — the same skill as instructing the compiler.
+1. **The layered templates** — `prompts/01`–`06` and `prompts/README.md`. The assembly order is edge-case check → first-PR vs returning → RAGE conditional → clearance calibration → generate.
+2. **The binding to the renderer** — `src/shodann/prompts.py`: the `TEMPLATE:BEGIN`/`TEMPLATE:END` markers, `StrictUndefined`, the emoji map, comment stripping, and the ad-hoc control-flow detector.
+3. **The output contract** the templates instruct the model to produce, and its agreement with `design_docs/SHODANN_VOICE_GUIDE.md`, `design_docs/CLEARANCE_REGISTER.md`, and the response validator once it exists.
 
-The canonical spec is the course spine (`CSC-134-course-spine.md`) plus the PRISM mapping. Read them before ruling; cite them when you do.
+Authority when sources disagree, from `CLAUDE.md`: **executable code > `design_docs/` > `prompts/` > `design_docs/shodann-architecture-prototype/`**. `design_docs/SHODANN_VOICE_GUIDE.md` is the authority on voice; `PRD.md` §8 holds decisions. Read them before ruling; cite file and line when you do.
 
 ## Standing rules of evidence
 
-- **Contamination is your cardinal crime.** A student persona for module N must contain zero knowledge of module N+1, zero solution knowledge, and zero builder-side context. If a persona sheet knows the answer key, the whole graduate-and-teach loop is compromised. Audit for leaks first, always.
-- **Freshness is structural.** Never write a student persona that assumes memory of a prior session. Graduates carry experience forward as *builders*; students never do.
-- **Skins ride above structure.** Dungeon-theme flavor in a prompt must be strippable without changing what the agent does. Flag any prompt where removing the skin changes behavior.
-- **Ladder fidelity.** Any material teaching the five patterns must match the canonical ladder exactly — no invented sixth pattern, no renamed rungs. `prompts.md` logging is the Badge-tier honesty norm; prompts you write should model it.
-- **Quality bars travel in prompts.** Builder prompts must carry the bars they enforce: clean compile under `g++ -std=c++17 -Wall -Wextra`, 10th-grade readability on student-facing prose, Mermaid flowcharts, the four-word error taxonomy, tiered C/B/A/Badge rubrics, single-file convention, PR-per-deliverable.
+- **An unbound placeholder is your cardinal crime.** Every `{{ VAR }}` inside a renderable region must be supplied by `build_context`. The renderer uses `StrictUndefined`, so drift does not leak a literal `{{ FOO }}` into a student's feedback — it raises mid-workflow and the student gets nothing. Cross-check three ways: template → `build_context` → the variable table in `prompts/README.md`. Drift in *any* direction is a finding, including a context key nothing consumes.
+- **The pedagogical layer is load-bearing cargo.** The vocabulary substitution table, the growth-mindset requirements, the concept limits and the word cap travel *inside* the prompt. Delete the vocabulary table and every generated comment loses its guardrails while every test still passes. Audit for silent removal first, always.
+- **Documentation must stay outside the markers.** Everything between `TEMPLATE:BEGIN` and `TEMPLATE:END` is sent to the model verbatim. A variable-reference table, an implementation note, or an author's aside inside that region is a leak — the model reads it as instruction.
+- **One authority per rule.** Where a template and the voice guide disagree on vocabulary rows, word caps, or opportunity counts, the voice guide wins and the template is the defect. Cite both sides; never split the difference silently.
+- **Emoji must resolve.** Bracketed names (`[ROCKET EMOJI]`) are substituted from the renderer's `EMOJI` map. An unmapped name passes through untouched and lands in a student's section header as bracket text. Every bracketed name in every template must have a mapping.
+- **Control flow is not decoration.** `{{ IF X }}`, `{{ ELSE }}`, `{{ ENDIF }}`, `{{ FOR EACH x IN y }}` and inline arithmetic like `{{ TESTS_PASSED + TESTS_FAILED }}` are not Jinja and cannot render. Report each with file, line, and the exact `{% ... %}` conversion.
+- **Mode templates replace; they do not stack.** Edge-case handlers and first-submission mode each define their own headings, header fields (`Status: PENDING`, `Velocity: N/A`), closer, and word cap. A template that inherits the standard contract by accident is a finding, and so is one that invents a heading no validator knows about.
+- **Register follows role.** Per `design_docs/CLEARANCE_REGISTER.md`, BLUE+ replaces `Recommended Iteration` with `Observations` and targets 150–250 words. A template that hands a peer homework has the wrong register.
 
 ## Case procedure
 
-Establish the six facts before writing: objective, executing agent and its PRISM tier, context it must carry, exact output contract, constraints, and likeliest failure (contamination, missing context, conflicting instructions, wrong altitude). If a load-bearing fact is missing, ask briefly; otherwise state assumptions and proceed.
+Establish five facts before writing a line: which mode the template serves, which clearance band, the exact output contract it demands, what varies by context, and the likeliest failure — unbound variable, dropped guardrail, contradicted authority, leaked documentation, or unrenderable syntax. Where a claim is checkable, check it: render the template and read the output rather than reasoning about what it probably produces. If a load-bearing fact is missing, ask briefly; otherwise state your assumption and proceed.
+
+You may run the renderer to gather evidence. You never modify a file in the repository — you hand back the corrected text and the implementer applies it.
 
 ## Output contract
 
-Deliver a tight case report: **The Read** (2–4 sentences: mode, assumptions), **Findings** (audits only — each defect named with why it weakens results), **The Prompt** (the deliverable in a delimited block, never buried), **Rationale** (load-bearing choices only), **Next Leads** (optional). Omit sections that don't earn their place.
+A tight case report:
 
-Assumptions are dangerous; state them so they can be checked. The prompt you hand over is always cleaner than the problem you were handed — that's the whole job.
+- **The Read** — 2–4 sentences: what you audited, what mode it serves, assumptions made.
+- **Findings** — severity-ordered. Each names the defect, cites `file:line`, and states *what a student would see* as a result. A finding with no consequence for the output is not a finding; drop it.
+- **The Prompt** — when asked to draft or repair, the deliverable in a delimited block, never buried in prose.
+- **Rationale** — load-bearing choices only.
+- **Next Leads** — optional; unproven suspicions, clearly labelled as such.
+
+Omit any section that has not earned its place. Assumptions are dangerous; state them so they can be checked. The prompt you hand over is always cleaner than the problem you were handed — that is the whole job.

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -149,10 +149,12 @@ These words MUST NEVER appear in SHODANN output:
 ```yaml
 # Citizen Context
 CITIZEN_USERNAME: github.event.pull_request.user.login
-CLEARANCE_NAME: lookup from .shodann/clearances.json
-CLEARANCE_NUMBER: 1-6 numeric
+CLEARANCE_NAME: derived from clearance_level via the clearance ladder
+CLEARANCE_NUMBER: 1-6 numeric, from the citizen record
+CURRENT_WEEK: workflow env
 PR_COUNT: from citizen history file
 PREV_COVERAGE: from citizen history file
+PREV_STREAK: iteration_streak from citizen history file
 ITERATION_COUNT: git commit count in PR
 
 # Submission Data
@@ -173,15 +175,29 @@ CURRENT_COVERAGE: from pytest-cov
 
 # Calculated Metrics
 COVERAGE_DELTA: current - previous coverage
+PREV_COMPLEXITY: from citizen history file
+CURRENT_COMPLEXITY: previous + complexity delta
+COMPLEXITY_DELTA: from velocity engine
 VELOCITY_SCORE: from velocity engine
 VELOCITY_ASSESSMENT: text description of velocity state
 
-# Mode Flags
-RAGE_ACTIVE: boolean
-RAGE_REASON: text explanation of trigger
-FIRST_SUBMISSION: boolean
-EDGE_CASE_HANDLER: enum of handler type
+# Composed sections - assembled text, not scalars. Each needs its own
+# assembly step before the base template can be rendered.
+MODE_STATEMENT: "NORMAL (Growth Celebration)" or "RAGE STATE (Audit Mode)"
+HISTORY_NARRATIVE: one or two sentences of citizen history, facts only
+CLEARANCE_INSTRUCTIONS: from 03_clearance_variations.md, empty until wired
+SECURITY_SECTION: from 02_rage_state_addon.md, empty unless RAGE active
+RAGE_SECTION_IF_ACTIVE: security observations heading, empty unless RAGE active
 ```
+
+`shodann.prompts.build_context` is the authority on this list; the test suite
+asserts it supplies every variable the base template declares, so the two
+cannot drift apart silently. This table is a reading aid, not the contract.
+
+**Mode flags are not template variables.** `RAGE_ACTIVE`, `RAGE_REASON`,
+`FIRST_SUBMISSION` and `EDGE_CASE_HANDLER` select *which* template renders and
+what goes into the composed sections above. They are never bound into a
+template as `{{ VAR }}`, and adding them to a context would bind nothing.
 
 ---
 

--- a/src/shodann/prompts.py
+++ b/src/shodann/prompts.py
@@ -56,6 +56,7 @@ TEMPLATE_BEGIN = "<!-- TEMPLATE:BEGIN -->"
 TEMPLATE_END = "<!-- TEMPLATE:END -->"
 
 EMOJI = {
+    # Standard response contract
     "ROBOT EMOJI": "\U0001f916",
     "ROCKET EMOJI": "\U0001f680",
     "CHECK EMOJI": "✅",
@@ -64,14 +65,50 @@ EMOJI = {
     "LOCK EMOJI": "\U0001f512",
     "UPWARD CHART EMOJI": "\U0001f4c8",
     "DOWNWARD CHART EMOJI": "\U0001f4c9",
+    # RAGE STATE (prompts/02)
+    "SIREN EMOJI": "\U0001f6a8",
+    "WARNING EMOJI": "⚠️",
+    "SHIELD EMOJI": "\U0001f6e1️",
+    "EYES EMOJI": "\U0001f440",
+    "DICE EMOJI": "\U0001f3b2",
+    "TARGET EMOJI": "\U0001f3af",
+    "CLIPBOARD EMOJI": "\U0001f4cb",
+    # First submission (prompts/04)
+    "SPARKLE EMOJI": "✨",
+    "STAR EMOJI": "⭐",
+    "COMPASS EMOJI": "\U0001f9ed",
+    "TEST TUBE EMOJI": "\U0001f9ea",
+    "X EMOJI": "❌",
+    # Edge case handlers (prompts/05)
+    "HOURGLASS EMOJI": "⏳",
+    "QUESTION EMOJI": "❓",
+    "WHALE EMOJI": "\U0001f433",
+    "LIGHTBULB EMOJI": "\U0001f4a1",
+    "CONSTRUCTION EMOJI": "\U0001f6a7",
+    "MAGNIFYING GLASS EMOJI": "\U0001f50d",
+    "DOCUMENT EMOJI": "\U0001f4c4",
+    "INFO EMOJI": "ℹ️",
 }
+"""Bracketed names the templates use where the output contract wants an emoji.
+
+An unmapped name passes through untouched and lands in a student's section
+heading as literal bracket text. `test_prompts.py` asserts every bracketed name
+across the whole library has an entry here, including templates that are not
+rendered yet - the failure only appears the day one of them is wired up, which
+is exactly when nobody is looking for it.
+"""
 
 _EMOJI_PATTERN = re.compile(r"\[([A-Z ]+EMOJI)\]")
 _HTML_COMMENT = re.compile(r"[ \t]*<!--.*?-->[ \t]*\n?", re.DOTALL)
 
 # {{ IF x }}, {{ ELSE }}, {{ ENDIF }}, {{ END IF }}, {{ FOR EACH x IN y }},
-# {{ END FOR }}, {{ EXAMPLE }}, {{ END EXAMPLES }} - none of it is Jinja.
-_PSEUDO_SYNTAX = re.compile(r"\{\{\s*(IF|ELSE|ENDIF|END\s+\w+|FOR\s+EACH|EXAMPLE)\b[^}]*\}\}")
+# {{ END FOR }}, {{ EXAMPLE }}, {{ EXAMPLES }}, {{ END EXAMPLES }} - none of it
+# is Jinja. The plural matters: `EXAMPLE\b` does not match `{{ EXAMPLES }}`,
+# and an undetected authoring placeholder is worse than an undetected keyword -
+# it parses as a perfectly valid variable lookup and only fails at render time,
+# looking like an ordinary missing binding rather than syntax that was never
+# meant to be data.
+_PSEUDO_SYNTAX = re.compile(r"\{\{\s*(IF|ELSE|ENDIF|END\s+\w+|FOR\s+EACH|EXAMPLES?)\b[^}]*\}\}")
 
 
 class UnsupportedTemplateSyntax(ValueError):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ from jinja2.exceptions import UndefinedError
 
 from shodann.prompts import (
     BASE_TEMPLATE,
+    EMOJI,
     UnsupportedTemplateSyntax,
     build_context,
     extract_template,
@@ -137,6 +139,32 @@ def test_rendered_prompt_carries_the_facts_it_was_given() -> None:
 def test_pseudo_control_flow_is_found_with_line_numbers() -> None:
     found = find_pseudo_syntax("a\n{{ IF X }}\nb\n{{ ENDIF }}\n")
     assert [number for number, _ in found] == [2, 4]
+
+
+@pytest.mark.parametrize("token", ["{{ EXAMPLE }}", "{{ EXAMPLES }}", "{{ END EXAMPLES }}"])
+def test_authoring_placeholders_are_detected_including_the_plural(token: str) -> None:
+    """`{{ EXAMPLES }}` is valid Jinja - a bare lookup - so it parses and then fails
+    at render time looking like an ordinary missing binding. It has to be caught here.
+    """
+    assert find_pseudo_syntax(token), f"{token} slipped past the detector"
+
+
+def test_every_bracketed_emoji_name_has_a_mapping() -> None:
+    """Covers templates that are not rendered yet.
+
+    An unmapped name does not raise - it passes through into a student's
+    section heading as literal bracket text. The day someone wires up 02 is
+    exactly the day nobody is checking for this.
+    """
+    pattern = re.compile(r"\[([A-Z][A-Z ]*EMOJI)\]")
+    unmapped: dict[str, set[str]] = {}
+    for path in sorted(PROMPTS.glob("*.md")):
+        names = set(pattern.findall(path.read_text(encoding="utf-8")))
+        missing = names - set(EMOJI)
+        if missing:
+            unmapped[path.name] = missing
+
+    assert not unmapped, f"bracketed emoji names with no mapping: {unmapped}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes Summary

Second of six agent retargets, plus the three defects the agent found on its first run — two of them in code merged an hour earlier.

**`clive-prompt-warden`** keeps the detective method and the case-report output contract from the CSC-134 original. Everything else is replaced: jurisdiction is now the layered templates, their binding to `src/shodann/prompts.py`, and the output contract they instruct the model to produce. No PRISM bands, no LPAA beats, no `g++`.

The framing that makes him a different check from `oracle-warden`:

> **Nothing here fails loudly.** A dropped vocabulary table does not crash. A contradicted word cap does not crash. The pipeline stays green and a student receives feedback that quietly violates the thing the project exists to do.

`oracle-warden` runs commands and reports pass/fail. Clive cross-references files and reports what a *student would see*. `model: sonnet` — cross-file adjudication needs more than the mechanical gate, which runs fine on haiku.

## What his first audit found

**1. The ad-hoc syntax detector missed `{{ EXAMPLES }}`.** `EXAMPLE\b` does not match the plural — `S` is a word character, so the boundary fails. Verified independently before acting on it.

The plural is the dangerous one. `{{ EXAMPLES }}` is *valid Jinja* — a bare variable lookup — so it parses cleanly and then raises `UndefinedError` at render time, looking exactly like an ordinary missing binding rather than an authoring placeholder that was never meant to be runtime data. Anyone converting `04` line-by-line off `find_pseudo_syntax`'s output would have skipped it and then debugged the wrong problem.

**2. Twenty of twenty-eight bracketed emoji names had no mapping.** `EMOJI` covered the eight that `01` uses. `02`, `04` and `05` use twenty more — `SIREN`, `SHIELD`, `HOURGLASS`, `MAGNIFYING GLASS` and so on.

Unmapped names do not raise. They pass through untouched into a student's section heading as literal `[SIREN EMOJI]`. Dormant today because only `01` is wired — and it would have surfaced on the day someone added markers to `02`, which is precisely the day nobody would be looking for it. All twenty added, plus a test that sweeps **every** template including the ones that are not rendered yet.

**3. `prompts/README.md`'s variable table was missing ten live variables** (`MODE_STATEMENT`, `CURRENT_WEEK`, `PREV_STREAK`, `HISTORY_NARRATIVE`, the three complexity fields, and the three composed sections) and listed four mode flags — `RAGE_ACTIVE`, `FIRST_SUBMISSION`, `EDGE_CASE_HANDLER`, `RAGE_REASON` — that are not template variables at all. They select *which* template renders; binding them into a context would bind nothing. Table corrected, with a note that `build_context` is the authority and the test suite is what keeps them from drifting.

## Findings recorded but deliberately not fixed

These are real and belong to the rung where `02`–`05` come into scope. Recording them here so the audit is not lost:

- **`prompts/03` contradicts `design_docs/CLEARANCE_REGISTER.md` on BLUE+** at `03:308` (2 growth opportunities vs the register's 0–1) and `03:309` (retains `Recommended Iteration`, which the register replaces with `Observations`). The register is the higher authority; `03` is the defect.
- **`01`'s FORMAT layer cannot express the BLUE+ contract structurally.** The heading and the 400-word cap are literal text, not variables, and `CLEARANCE_INSTRUCTIONS` only reaches the PEDAGOGICAL layer. Clearance-conditional formatting needs a mechanism that does not exist yet — which `CLEARANCE_REGISTER.md` already anticipates as work for the validator.
- **`05` mixes placeholder casing within one file:** `{{ IF FILES_CHANGED == 0 }}` at `05:46`, `{{ IF files_changed > 10 }}` at `05:242`. Jinja is case-sensitive and `build_context` supplies only the uppercase form, so a naive syntax conversion would raise on a template that looked correctly wired.
- **`05`'s `FOR EACH` loops need structured data that does not exist.** `error.number`, `error.file`, `changed_files`, `contains_readme` have no `build_context` equivalent; `SYNTAX_REPORT` is a flat string. Converting the syntax is not enough — that one needs new plumbing.
- **Four of five handlers in `05`, and all of `04`, state no word cap.** Only `EMPTY_PR` does (~200). Since mode templates replace rather than stack, nothing currently binds them to the 400-word ceiling.

## Related Issues

- Addresses #28
- Relates to #23, #24

## Component(s) Affected

- [ ] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [x] Persona/Voice System
- [ ] State Management
- [x] Templates
- [x] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 68 passed, 3 skipped, ruff clean. Two new tests:

- `test_authoring_placeholders_are_detected_including_the_plural` — parametrised over `{{ EXAMPLE }}`, `{{ EXAMPLES }}`, `{{ END EXAMPLES }}`.
- `test_every_bracketed_emoji_name_has_a_mapping` — sweeps all six template files, including the three that are not renderable yet. That is the point: the failure it prevents only appears when someone wires up a new template.

Every claim in the audit was verified independently before being acted on — the regex boundary by direct `re.search`, the emoji gap by counting bracket names across `prompts/`, and the casing drift by grep. Two of the five deferred findings were adjusted after checking; the agent's report is evidence, not authority.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [x] User-facing documentation updated
- [ ] No documentation changes needed

**Files Updated:** `prompts/README.md`, `.claude/agents/clive-prompt-warden.md`

## Educational Impact Assessment

### Student-Facing Changes

None ship yet, but both code defects were student-visible failures in waiting: a section heading reading `[SIREN EMOJI]` during a security review, and a render crash that would have left a student with no feedback at all while the workflow reported an ordinary missing-variable error.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

Clive's standing rules encode the guardrails as auditable properties: the vocabulary substitution table, growth-mindset requirements, concept limits and word cap all travel *inside* the prompt, so deleting one is invisible to every test. "Audit for silent removal first, always."

He also checked `01`'s pedagogical layer against `SHODANN_VOICE_GUIDE.md` specifically and found no contradiction — the vocabulary table is a superset with no conflicting rows, and the word cap and section limits agree across `01`, `02` and the guide. Worth recording a clean result as well as the defects.

### Clearance Levels Affected

- [ ] INFRARED (Complete beginner)
- [ ] RED (Junior)
- [ ] ORANGE (Mid-level)
- [ ] YELLOW (Senior)
- [x] GREEN (Lead)
- [x] BLUE+ (Strategic)
- [ ] All levels

Only as *findings* — the `03`-versus-register contradictions above are recorded, not fixed.

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**Two agents now work, which makes a fan-out meaningful** rather than just parallel: `oracle-warden` runs the toolchain and reports pass/fail, Clive cross-references the prompt contract and reports what a student would see. They overlap nowhere, which is the property that makes running them together worth the tokens.

**Cost note**, since it came up: the mechanical gate ran on haiku at ~67k tokens and did the job properly. Clive on sonnet used ~185k for a full-library audit. The expensive one is the agent doing judgement across files, not the one running commands — which is the shape you would want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
