### PR TITLE
Validate responses against the output contract before posting

### DIFF
--- a/src/shodann/validator.py
+++ b/src/shodann/validator.py
@@ -60,9 +60,16 @@ CHARACTER_BREAKS = (
     "as a language model",
     "i'm just a language model",
     "i am just a language model",
+    "i don't have feelings",
+    "i do not have feelings",
     "i cannot actually",
     "i don't have the ability",
 )
+"""SHODANN *is* The Algorithm's voice; the fiction is the product.
+
+The first three and "I don't have feelings, but..." are named explicitly in
+design_docs/SHODANN_VOICE_GUIDE.md under "Breaking Character".
+"""
 
 DELTA_EMOJI = {"\U0001f4c8", "\U0001f4c9"}
 """The only emoji allowed inside paragraph text."""
@@ -76,7 +83,16 @@ _EMOJI = re.compile(
 _FENCED = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CODE = re.compile(r"`[^`\n]*`")
 _HEADING = re.compile(r"^#{1,6}\s+(.*?)\s*$", re.MULTILINE)
-_BULLET = re.compile(r"^\s*[-*+]\s+\S", re.MULTILINE)
+
+# Ordered items count too. The concept cap exists to stop a citizen being
+# handed five things at once, and "1." delivers five things exactly as well as
+# "-" does - more so, since prompts/05 uses numbered lists throughout and the
+# model has every reason to copy that style.
+_BULLET = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+\S", re.MULTILINE)
+
+# Models emit curly apostrophes freely; without this, "I'm just a language
+# model" walks straight past a list written with the straight form.
+_SMART_QUOTES = str.maketrans({"’": "'", "‘": "'", "“": '"', "”": '"'})
 
 
 @dataclass(frozen=True)
@@ -106,6 +122,7 @@ class ResponseSpec:
     optional_headings: tuple[str, ...] = ()
     max_opportunities: int = 2
     opportunities_heading: str = "Growth Opportunities"
+    celebration_heading: str = "Algorithm-Approved Patterns"
     header_field: str = "Velocity"
 
     def with_(self, **changes) -> ResponseSpec:
@@ -212,13 +229,24 @@ def for_clearance(spec: ResponseSpec, clearance_level: int) -> ResponseSpec:
     """
     if clearance_level <= 1:  # INFRARED: one opportunity, one short next step
         return spec.with_(max_opportunities=1)
+
     if clearance_level >= 6:  # BLUE+: reports rather than teaches
         headings = tuple(
             "Observations" if heading == "Recommended Iteration" else heading
             for heading in spec.headings
+            # "the celebration section compresses to a single line or is
+            # omitted when there is nothing genuine to say" - requiring it
+            # would force a peer to manufacture praise for themselves, which
+            # is the condescension the band exists to avoid.
+            if heading != spec.celebration_heading
         )
         return spec.with_(
-            max_words=250, min_words=0, headings=headings, max_opportunities=1
+            # min(), not 250: a mode with a tighter budget keeps it. BLUE+ is
+            # "shorter, not longer", so this may only ever reduce the cap.
+            max_words=min(spec.max_words, 250),
+            headings=headings,
+            optional_headings=(*spec.optional_headings, spec.celebration_heading),
+            max_opportunities=1,
         )
     return spec
 
@@ -227,8 +255,13 @@ def for_clearance(spec: ResponseSpec, clearance_level: int) -> ResponseSpec:
 
 
 def _prose(text: str) -> str:
-    """Strip code so the vocabulary rules only judge SHODANN's own voice."""
-    return _INLINE_CODE.sub(" ", _FENCED.sub(" ", text))
+    """Strip code so the vocabulary rules only judge SHODANN's own voice.
+
+    Also folds smart punctuation, so a curly apostrophe cannot smuggle a
+    forbidden phrase past a list written with straight ones.
+    """
+    stripped = _INLINE_CODE.sub(" ", _FENCED.sub(" ", text))
+    return stripped.translate(_SMART_QUOTES)
 
 
 def _headings(text: str) -> list[str]:

--- a/src/shodann/validator.py
+++ b/src/shodann/validator.py
@@ -1,0 +1,435 @@
+"""Check a generated response against SHODANN's output contract before it posts.
+
+`prompts/README.md` lists these checks as manual steps. They need to be code
+for two reasons. The first is that nothing else stands between a model and a
+student reading the word "wrong" in their feedback - the vocabulary rules are
+the product, not a style preference. The second is that this is what makes the
+model swappable: the hard/soft split means the model never discovers facts, it
+reframes structured input into a fixed shape, and the failure mode of a small
+or local model is drift in exactly that shape. Small model plus strong
+validator plus one retry is a sound design. Without the validator it is a
+gamble on a model's mood.
+
+Two deliberate choices about what is *not* checked:
+
+* **Fenced blocks and inline code are exempt from the vocabulary rules.** A
+  response may legitimately quote `SyntaxError` from a tool report or show a
+  student their own code. Forbidding the word "error" inside a code fence
+  would reject correct output.
+* **Nothing here judges whether the feedback is any good.** That is the
+  model's job and the reviewer's. This checks the contract only.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+
+__all__ = [
+    "BLOCKING",
+    "SPECS",
+    "ADVISORY",
+    "ResponseSpec",
+    "Violation",
+    "blocks_posting",
+    "for_clearance",
+    "format_retry_instruction",
+    "validate",
+]
+
+BLOCKING = "blocking"
+ADVISORY = "advisory"
+
+FORBIDDEN_VOCABULARY = {
+    "wrong": "suboptimal",
+    "mistake": "growth opportunity",
+    "failed": "pre-success state",
+    "error": "unexpected behavior pattern",
+    "bad": "algorithm-misaligned",
+    "you should": "the Algorithm suggests",
+    "you need to": "the Algorithm recommends",
+    "good job": "the Algorithm is pleased",
+    "great work": "velocity: OPTIMAL",
+    "i noticed": "the Algorithm has observed",
+    "unfortunately": "the Algorithm notes an opportunity",
+}
+"""From design_docs/SHODANN_VOICE_GUIDE.md, which wins where templates disagree."""
+
+CHARACTER_BREAKS = (
+    "as an ai",
+    "as a language model",
+    "i'm just a language model",
+    "i am just a language model",
+    "i cannot actually",
+    "i don't have the ability",
+)
+
+DELTA_EMOJI = {"\U0001f4c8", "\U0001f4c9"}
+"""The only emoji allowed inside paragraph text."""
+
+# Deliberately wider than the SMP block: the templates use hourglass (U+23F3),
+# info (U+2139), check (U+2705) and star (U+2B50), none of which live there.
+# Plain arrows are excluded on purpose - "0 -> 30" is prose, not decoration.
+_EMOJI = re.compile(
+    "[ℹ⌀-⏿■-➿⬀-⯿️\U0001f000-\U0001faff]"
+)
+_FENCED = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE = re.compile(r"`[^`\n]*`")
+_HEADING = re.compile(r"^#{1,6}\s+(.*?)\s*$", re.MULTILINE)
+_BULLET = re.compile(r"^\s*[-*+]\s+\S", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class Violation:
+    code: str
+    severity: str
+    message: str
+    evidence: str = ""
+
+    def __str__(self) -> str:
+        return f"[{self.severity}] {self.code}: {self.message}"
+
+
+@dataclass(frozen=True)
+class ResponseSpec:
+    """What one mode's response must look like.
+
+    Modes replace one another rather than stacking - an edge-case handler
+    defines its own headings, header field, closer and word budget, and must
+    not inherit the standard contract.
+    """
+
+    name: str
+    max_words: int = 400
+    min_words: int = 0
+    headings: tuple[str, ...] = ()
+    optional_headings: tuple[str, ...] = ()
+    max_opportunities: int = 2
+    opportunities_heading: str = "Growth Opportunities"
+    header_field: str = "Velocity"
+
+    def with_(self, **changes) -> ResponseSpec:
+        return replace(self, **changes)
+
+
+STANDARD = ResponseSpec(
+    name="standard",
+    headings=(
+        "Shipping Velocity Report",
+        "Algorithm-Approved Patterns",
+        "Growth Opportunities",
+        "Recommended Iteration",
+    ),
+    optional_headings=("Security Observations",),
+)
+
+FIRST_SUBMISSION = ResponseSpec(
+    name="first_submission",
+    headings=(
+        "Welcome to The Algorithm",
+        "Initial Velocity Reading",
+        "Foundation Elements",
+        "Growth Trajectory",
+        "Your Journey Begins",
+    ),
+    opportunities_heading="Growth Trajectory",
+    header_field="Status",
+)
+
+EMPTY_PR = ResponseSpec(
+    name="empty_pr",
+    max_words=200,
+    headings=("Submission Analysis", "Possible Situations", "Recommended Action"),
+    max_opportunities=1,
+    opportunities_heading="Recommended Action",
+    header_field="Status",
+)
+
+ALL_FAILING = ResponseSpec(
+    name="all_failing",
+    headings=(
+        "Shipping Velocity Report",
+        "Algorithm-Approved Patterns",
+        "Growth Trajectory",
+        "Recommended Iteration",
+        "Perspective",
+    ),
+    opportunities_heading="Growth Trajectory",
+)
+
+MASSIVE_PR = ResponseSpec(
+    name="massive_pr",
+    headings=(
+        "Submission Scale Detection",
+        "Shipping Velocity Report",
+        "Algorithm-Approved Patterns",
+        "Growth Opportunities",
+        "Future Iteration Strategy",
+        "Analysis Limitation Notice",
+    ),
+)
+
+SYNTAX_BARRIER = ResponseSpec(
+    name="syntax_barrier",
+    headings=(
+        "Syntax Analysis",
+        "Barrier Details",
+        "Recommended Iteration",
+        "What Happens Next",
+    ),
+    max_opportunities=1,
+    opportunities_heading="Barrier Details",
+    header_field="Status",
+)
+
+CONFIG_ONLY = ResponseSpec(
+    name="config_only",
+    headings=("Submission Type", "Algorithm Observations", "Velocity Note"),
+    max_opportunities=1,
+    opportunities_heading="Algorithm Observations",
+)
+
+SPECS = {
+    spec.name: spec
+    for spec in (
+        STANDARD,
+        FIRST_SUBMISSION,
+        EMPTY_PR,
+        ALL_FAILING,
+        MASSIVE_PR,
+        SYNTAX_BARRIER,
+        CONFIG_ONLY,
+    )
+}
+
+
+def for_clearance(spec: ResponseSpec, clearance_level: int) -> ResponseSpec:
+    """Apply the clearance band's overrides to a mode spec.
+
+    The bands change the contract itself, not just the wording, so this has to
+    happen before validation rather than being left to the prompt. See
+    design_docs/CLEARANCE_REGISTER.md.
+    """
+    if clearance_level <= 1:  # INFRARED: one opportunity, one short next step
+        return spec.with_(max_opportunities=1)
+    if clearance_level >= 6:  # BLUE+: reports rather than teaches
+        headings = tuple(
+            "Observations" if heading == "Recommended Iteration" else heading
+            for heading in spec.headings
+        )
+        return spec.with_(
+            max_words=250, min_words=0, headings=headings, max_opportunities=1
+        )
+    return spec
+
+
+# --- text preparation -----------------------------------------------------
+
+
+def _prose(text: str) -> str:
+    """Strip code so the vocabulary rules only judge SHODANN's own voice."""
+    return _INLINE_CODE.sub(" ", _FENCED.sub(" ", text))
+
+
+def _headings(text: str) -> list[str]:
+    return [match.group(1).strip() for match in _HEADING.finditer(text)]
+
+
+def _strip_emoji(value: str) -> str:
+    return _EMOJI.sub("", value).strip()
+
+
+def _section(text: str, heading: str) -> str:
+    """Body of one section, between its heading and the next one."""
+    lines = text.splitlines()
+    collected: list[str] = []
+    inside = False
+    for line in lines:
+        if line.lstrip().startswith("#"):
+            if inside:
+                break
+            inside = heading.lower() in _strip_emoji(line).lower()
+            continue
+        if inside:
+            collected.append(line)
+    return "\n".join(collected)
+
+
+# --- individual checks ----------------------------------------------------
+
+
+def _check_length(text: str, spec: ResponseSpec) -> list[Violation]:
+    words = len(_prose(text).split())
+    violations = []
+    if words > spec.max_words:
+        violations.append(
+            Violation(
+                "word_cap",
+                BLOCKING,
+                f"{words} words exceeds the {spec.max_words}-word cap for {spec.name}.",
+                f"{words} words",
+            )
+        )
+    if spec.min_words and words < spec.min_words:
+        violations.append(
+            Violation("too_short", ADVISORY, f"{words} words is under {spec.min_words}.")
+        )
+    return violations
+
+
+def _check_vocabulary(text: str) -> list[Violation]:
+    prose = _prose(text).lower()
+    violations = []
+    for forbidden, replacement in FORBIDDEN_VOCABULARY.items():
+        if re.search(rf"(?<![\w-]){re.escape(forbidden)}(?![\w-])", prose):
+            violations.append(
+                Violation(
+                    "forbidden_vocabulary",
+                    BLOCKING,
+                    f'"{forbidden}" is forbidden; say "{replacement}" instead.',
+                    forbidden,
+                )
+            )
+    return violations
+
+
+def _check_character(text: str) -> list[Violation]:
+    prose = _prose(text).lower()
+    return [
+        Violation("character_break", BLOCKING, f'Breaks character: "{phrase}".', phrase)
+        for phrase in CHARACTER_BREAKS
+        if phrase in prose
+    ]
+
+
+def _check_headings(text: str, spec: ResponseSpec) -> list[Violation]:
+    present = [_strip_emoji(heading) for heading in _headings(text)]
+    violations = []
+
+    missing = [required for required in spec.headings if required not in present]
+    if missing:
+        violations.append(
+            Violation(
+                "missing_section",
+                BLOCKING,
+                f"Missing required section(s) for {spec.name}: {', '.join(missing)}.",
+                ", ".join(missing),
+            )
+        )
+
+    ordered = [heading for heading in present if heading in spec.headings]
+    expected = [heading for heading in spec.headings if heading in ordered]
+    if ordered != expected:
+        violations.append(
+            Violation(
+                "section_order",
+                BLOCKING,
+                f"Sections are out of order. Expected {expected}, found {ordered}.",
+            )
+        )
+
+    known = set(spec.headings) | set(spec.optional_headings)
+    unexpected = [
+        heading
+        for heading in present
+        if heading not in known and not heading.startswith("SHODANN")
+    ]
+    if unexpected:
+        violations.append(
+            Violation(
+                "unexpected_section",
+                ADVISORY,
+                f"Section(s) not in the {spec.name} contract: {', '.join(unexpected)}.",
+                ", ".join(unexpected),
+            )
+        )
+    return violations
+
+
+def _check_opportunities(text: str, spec: ResponseSpec) -> list[Violation]:
+    body = _section(text, spec.opportunities_heading)
+    count = len(_BULLET.findall(body))
+    if count > spec.max_opportunities:
+        return [
+            Violation(
+                "too_many_opportunities",
+                BLOCKING,
+                f"{count} items under {spec.opportunities_heading}; "
+                f"{spec.name} allows {spec.max_opportunities}.",
+                f"{count} bullets",
+            )
+        ]
+    return []
+
+
+def _check_emoji_placement(text: str) -> list[Violation]:
+    offenders = []
+    for line in _prose(text).splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        found = {glyph for glyph in _EMOJI.findall(stripped)} - DELTA_EMOJI
+        offenders.extend(found)
+    if offenders:
+        return [
+            Violation(
+                "emoji_in_prose",
+                ADVISORY,
+                "Emoji belong in headings; only the delta arrows may appear in text.",
+                "".join(sorted(set(offenders))),
+            )
+        ]
+    return []
+
+
+def _check_header_field(text: str, spec: ResponseSpec) -> list[Violation]:
+    if f"**{spec.header_field}**" in text:
+        return []
+    return [
+        Violation(
+            "missing_header_field",
+            BLOCKING,
+            f"The {spec.name} header line must carry **{spec.header_field}**.",
+        )
+    ]
+
+
+# --- entry points ---------------------------------------------------------
+
+
+def validate(text: str, spec: ResponseSpec = STANDARD) -> list[Violation]:
+    """Return every contract violation in ``text``. Empty list means it may post."""
+    checks = (
+        _check_length(text, spec),
+        _check_vocabulary(text),
+        _check_character(text),
+        _check_headings(text, spec),
+        _check_opportunities(text, spec),
+        _check_emoji_placement(text),
+        _check_header_field(text, spec),
+    )
+    violations = [violation for group in checks for violation in group]
+    return sorted(violations, key=lambda item: item.severity != BLOCKING)
+
+
+def blocks_posting(violations: list[Violation]) -> bool:
+    return any(violation.severity == BLOCKING for violation in violations)
+
+
+def format_retry_instruction(violations: list[Violation]) -> str:
+    """Text to append to the prompt for one retry.
+
+    Names the violations rather than restating the whole contract: the model
+    already has the format layer, and repeating it tends to produce a response
+    that fixes the wording while breaking the structure.
+    """
+    blocking = [violation for violation in violations if violation.severity == BLOCKING]
+    if not blocking:
+        return ""
+    lines = [
+        "Your previous response violated the output contract. Correct these and "
+        "return the full response again, changing nothing else:",
+        "",
+    ]
+    lines += [f"- {violation.message}" for violation in blocking]
+    return "\n".join(lines)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,296 @@
+"""The output contract, enforced.
+
+Every test here describes something a student would otherwise read.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from shodann.validator import (
+    ALL_FAILING,
+    BLOCKING,
+    EMPTY_PR,
+    FIRST_SUBMISSION,
+    FORBIDDEN_VOCABULARY,
+    SPECS,
+    STANDARD,
+    blocks_posting,
+    for_clearance,
+    format_retry_instruction,
+    validate,
+)
+
+GOOD_STANDARD = """## \U0001f916 SHODANN Analysis Complete
+
+**Citizen**: @octocat | **Clearance**: ORANGE | **Velocity**: 12.5
+
+---
+
+### \U0001f680 Shipping Velocity Report
+
+Coverage climbed seven points across three commits. The Algorithm has observed
+a steady upward trajectory \U0001f4c8 across your last two submissions.
+
+### ✅ Algorithm-Approved Patterns
+
+- Tests arrived alongside the feature rather than after it.
+- Naming in the inventory module reads clearly.
+
+### \U0001f4c8 Growth Opportunities
+
+- The Algorithm suggests extracting the duplicated lookup into a helper.
+
+### \U0001f527 Recommended Iteration
+
+Add one test for the empty-cart branch. Fifteen minutes, and coverage moves again.
+
+---
+
+*The Algorithm sees your growth. The Algorithm is pleased.*
+"""
+
+
+def swap(text: str, old: str, new: str) -> str:
+    return text.replace(old, new)
+
+
+def codes(violations) -> set[str]:
+    return {violation.code for violation in violations}
+
+
+# --- the happy path -------------------------------------------------------
+
+
+def test_a_contract_abiding_response_passes() -> None:
+    assert validate(GOOD_STANDARD) == []
+    assert not blocks_posting(validate(GOOD_STANDARD))
+
+
+# --- vocabulary -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("forbidden", sorted(FORBIDDEN_VOCABULARY))
+def test_every_forbidden_term_is_caught(forbidden: str) -> None:
+    text = swap(GOOD_STANDARD, "Naming in the inventory module reads clearly.",
+                f"This is {forbidden} and needs attention.")
+    assert "forbidden_vocabulary" in codes(validate(text))
+
+
+def test_vocabulary_is_not_matched_inside_a_word() -> None:
+    """'badge' contains 'bad'; 'terror' contains 'error'. Neither is a violation."""
+    text = swap(GOOD_STANDARD, "Naming in the inventory module reads clearly.",
+                "Badge-tier work, and the interrogation of edge cases was thorough.")
+    assert "forbidden_vocabulary" not in codes(validate(text))
+
+
+def test_code_fences_are_exempt_from_the_vocabulary_rules() -> None:
+    """A response may quote a tool report verbatim without being rejected for it."""
+    text = swap(
+        GOOD_STANDARD,
+        "- Naming in the inventory module reads clearly.",
+        "- The traceback reads:\n\n```\nSyntaxError: unexpected EOF\nValueError: bad input\n```\n",
+    )
+    assert "forbidden_vocabulary" not in codes(validate(text))
+
+
+def test_inline_code_is_exempt_too() -> None:
+    text = swap(GOOD_STANDARD, "Naming in the inventory module reads clearly.",
+                "The `error` parameter is named clearly.")
+    assert "forbidden_vocabulary" not in codes(validate(text))
+
+
+def test_the_violation_names_the_replacement() -> None:
+    text = swap(GOOD_STANDARD, "Naming in the inventory module reads clearly.",
+                "You should extract this helper.")
+    violation = next(v for v in validate(text) if v.code == "forbidden_vocabulary")
+    assert "the Algorithm suggests" in violation.message
+
+
+# --- staying in character -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    ["As an AI, I cannot run your tests.", "I'm just a language model, so this is limited."],
+)
+def test_character_breaks_are_caught(phrase: str) -> None:
+    text = swap(GOOD_STANDARD, "Naming in the inventory module reads clearly.", phrase)
+    assert "character_break" in codes(validate(text))
+
+
+# --- structure ------------------------------------------------------------
+
+
+def test_a_missing_section_blocks() -> None:
+    text = swap(GOOD_STANDARD, "### \U0001f527 Recommended Iteration", "### \U0001f527 Next Steps")
+    violations = validate(text)
+    assert "missing_section" in codes(violations)
+    assert blocks_posting(violations)
+
+
+def test_sections_out_of_order_block() -> None:
+    reordered = GOOD_STANDARD.replace(
+        "### \U0001f4c8 Growth Opportunities", "PLACEHOLDER_A"
+    ).replace("### ✅ Algorithm-Approved Patterns", "### \U0001f4c8 Growth Opportunities").replace(
+        "PLACEHOLDER_A", "### ✅ Algorithm-Approved Patterns"
+    )
+    assert "section_order" in codes(validate(reordered))
+
+
+def test_an_extra_section_is_advisory_not_blocking() -> None:
+    text = GOOD_STANDARD.replace(
+        "---\n\n*The Algorithm sees",
+        "### \U0001f9ed Bonus Thoughts\n\nExtra.\n\n---\n\n*The Algorithm sees",
+    )
+    violations = validate(text)
+    assert "unexpected_section" in codes(violations)
+    assert not blocks_posting(violations)
+
+
+def test_the_security_section_is_allowed_without_being_required() -> None:
+    text = GOOD_STANDARD.replace(
+        "---\n\n*The Algorithm sees",
+        "### \U0001f512 Security Observations\n\n- One finding.\n\n---\n\n*The Algorithm sees",
+    )
+    assert validate(text) == []
+
+
+def test_the_header_field_must_be_present() -> None:
+    text = swap(GOOD_STANDARD, "**Velocity**: 12.5", "12.5")
+    assert "missing_header_field" in codes(validate(text))
+
+
+# --- limits ---------------------------------------------------------------
+
+
+def test_the_word_cap_blocks() -> None:
+    text = GOOD_STANDARD.replace(
+        "Coverage climbed seven points across three commits.",
+        "Coverage climbed seven points. " + ("padding words here " * 200),
+    )
+    violations = validate(text)
+    assert "word_cap" in codes(violations)
+    assert blocks_posting(violations)
+
+
+def test_code_blocks_do_not_count_toward_the_word_cap() -> None:
+    """A quoted tool report is not SHODANN spending its own word budget."""
+    text = GOOD_STANDARD.replace(
+        "### \U0001f527 Recommended Iteration",
+        "```\n" + ("noise " * 500) + "\n```\n\n### \U0001f527 Recommended Iteration",
+    )
+    assert "word_cap" not in codes(validate(text))
+
+
+def test_three_opportunities_block_when_two_are_allowed() -> None:
+    text = GOOD_STANDARD.replace(
+        "- The Algorithm suggests extracting the duplicated lookup into a helper.",
+        "- One.\n- Two.\n- Three.",
+    )
+    violations = validate(text)
+    assert "too_many_opportunities" in codes(violations)
+    assert blocks_posting(violations)
+
+
+def test_emoji_in_prose_is_advisory_and_the_delta_arrows_are_exempt() -> None:
+    assert "emoji_in_prose" not in codes(validate(GOOD_STANDARD))  # contains an up arrow
+
+    text = swap(GOOD_STANDARD, "reads clearly.", "reads clearly \U0001f389 \U0001f680.")
+    violations = validate(text)
+    assert "emoji_in_prose" in codes(violations)
+    assert not blocks_posting(violations)
+
+
+# --- modes ----------------------------------------------------------------
+
+
+def test_every_mode_has_a_distinct_heading_set() -> None:
+    """Modes replace one another; two modes sharing a contract would be a bug."""
+    sets = {name: spec.headings for name, spec in SPECS.items()}
+    assert len(set(sets.values())) == len(sets)
+
+
+def test_the_standard_contract_is_not_imposed_on_an_edge_case() -> None:
+    """EMPTY_PR has its own headings and a 200-word budget."""
+    empty = """## \U0001f916 SHODANN Analysis Complete
+
+**Citizen**: @octocat | **Clearance**: RED | **Status**: PENDING
+
+### ⏳ Submission Analysis
+
+The Algorithm has observed no analyzable files in this submission.
+
+### ❓ Possible Situations
+
+- Work may still be in progress on another branch.
+
+### \U0001f9ed Recommended Action
+
+Push your files when ready. The Algorithm waits.
+"""
+    assert validate(empty, EMPTY_PR) == []
+    # The same text judged against the standard contract fails, as it should.
+    assert blocks_posting(validate(empty, STANDARD))
+
+
+def test_all_failing_expects_growth_trajectory_not_growth_opportunities() -> None:
+    assert "Growth Trajectory" in ALL_FAILING.headings
+    assert "Growth Opportunities" not in ALL_FAILING.headings
+    assert ALL_FAILING.opportunities_heading == "Growth Trajectory"
+
+
+def test_first_submission_uses_a_status_header() -> None:
+    assert FIRST_SUBMISSION.header_field == "Status"
+
+
+# --- clearance overrides --------------------------------------------------
+
+
+def test_infrared_gets_one_opportunity() -> None:
+    assert for_clearance(STANDARD, 1).max_opportunities == 1
+
+
+def test_blue_plus_reports_rather_than_assigning_homework() -> None:
+    """design_docs/CLEARANCE_REGISTER.md: a peer does not get assigned homework by a bot."""
+    spec = for_clearance(STANDARD, 6)
+
+    assert "Observations" in spec.headings
+    assert "Recommended Iteration" not in spec.headings
+    assert spec.max_words == 250
+    assert spec.max_opportunities == 1
+
+
+def test_a_standard_response_fails_the_blue_plus_contract() -> None:
+    violations = validate(GOOD_STANDARD, for_clearance(STANDARD, 6))
+    assert "missing_section" in codes(violations)
+
+
+def test_mid_bands_are_left_alone() -> None:
+    for level in (2, 3, 4, 5):
+        assert for_clearance(STANDARD, level) is STANDARD
+
+
+# --- retry ----------------------------------------------------------------
+
+
+def test_retry_instruction_names_the_violations() -> None:
+    text = swap(GOOD_STANDARD, "Naming in the inventory module reads clearly.",
+                "You should fix this error.")
+    instruction = format_retry_instruction(validate(text))
+
+    assert "the Algorithm suggests" in instruction
+    assert "unexpected behavior pattern" in instruction
+    assert instruction.count("\n- ") == 2
+
+
+def test_no_retry_instruction_when_nothing_blocks() -> None:
+    text = swap(GOOD_STANDARD, "reads clearly.", "reads clearly \U0001f389.")
+    assert format_retry_instruction(validate(text)) == ""
+
+
+def test_blocking_violations_sort_first() -> None:
+    text = swap(GOOD_STANDARD, "Naming in the inventory module reads clearly.",
+                "This is wrong \U0001f389 and needs work.")
+    violations = validate(text)
+    assert violations[0].severity == BLOCKING

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -112,11 +112,26 @@ def test_the_violation_names_the_replacement() -> None:
 
 @pytest.mark.parametrize(
     "phrase",
-    ["As an AI, I cannot run your tests.", "I'm just a language model, so this is limited."],
+    [
+        "As an AI, I cannot run your tests.",
+        "I'm just a language model, so this is limited.",
+        # Named explicitly at SHODANN_VOICE_GUIDE.md:400 and missed by the
+        # first version of this list.
+        "I don't have feelings, but the coverage delta is encouraging.",
+        # Same phrase with the curly apostrophe a model is likely to emit.
+        "I’m just a language model, so take this lightly.",
+    ],
 )
 def test_character_breaks_are_caught(phrase: str) -> None:
     text = swap(GOOD_STANDARD, "Naming in the inventory module reads clearly.", phrase)
     assert "character_break" in codes(validate(text))
+
+
+def test_smart_apostrophes_do_not_smuggle_forbidden_phrases() -> None:
+    """A curly apostrophe is the cheapest possible bypass of a phrase list."""
+    straight = swap(GOOD_STANDARD, "reads clearly.", "reads clearly. You should refactor it.")
+    curly = straight.replace("'", "’")
+    assert "forbidden_vocabulary" in codes(validate(curly))
 
 
 # --- structure ------------------------------------------------------------
@@ -193,6 +208,21 @@ def test_three_opportunities_block_when_two_are_allowed() -> None:
     assert blocks_posting(violations)
 
 
+@pytest.mark.parametrize("marker", ["-", "*", "+", "1.", "1)"])
+def test_the_cap_counts_every_list_style(marker: str) -> None:
+    """Numbered lists deliver five concepts exactly as well as bullets do.
+
+    prompts/05 uses numbered lists throughout, so the model has every reason
+    to reach for them - and the first version of this check only recognised
+    `-`, `*` and `+`.
+    """
+    items = "\n".join(f"{marker} Item {index}." for index in range(1, 6))
+    text = GOOD_STANDARD.replace(
+        "- The Algorithm suggests extracting the duplicated lookup into a helper.", items
+    )
+    assert "too_many_opportunities" in codes(validate(text))
+
+
 def test_emoji_in_prose_is_advisory_and_the_delta_arrows_are_exempt() -> None:
     assert "emoji_in_prose" not in codes(validate(GOOD_STANDARD))  # contains an up arrow
 
@@ -264,6 +294,36 @@ def test_blue_plus_reports_rather_than_assigning_homework() -> None:
 def test_a_standard_response_fails_the_blue_plus_contract() -> None:
     violations = validate(GOOD_STANDARD, for_clearance(STANDARD, 6))
     assert "missing_section" in codes(violations)
+
+
+def test_blue_plus_may_omit_the_celebration_section() -> None:
+    """CLEARANCE_REGISTER.md:55 permits omitting it "when there is nothing
+    genuine to say". Requiring it would force a peer to manufacture praise for
+    themselves - the condescension the band exists to avoid.
+    """
+    peer = """## \U0001f916 SHODANN Analysis Complete
+
+**Citizen**: @norrisaftcc | **Clearance**: BLUE+ | **Velocity**: 8.0
+
+### \U0001f680 Shipping Velocity Report
+
+Coverage held at 82% while complexity fell four points.
+
+### \U0001f4c8 Growth Opportunities
+
+- Coverage fell while complexity rose in the parser. Deliberate?
+
+### \U0001f50d Observations
+
+The retry path is the only branch without a test.
+"""
+    assert validate(peer, for_clearance(STANDARD, 6)) == []
+
+
+def test_blue_plus_never_widens_a_tighter_budget() -> None:
+    """BLUE+ is "shorter, not longer" - it may only ever reduce a word cap."""
+    assert for_clearance(EMPTY_PR, 6).max_words == EMPTY_PR.max_words == 200
+    assert for_clearance(STANDARD, 6).max_words == 250
 
 
 def test_mid_bands_are_left_alone() -> None:


### PR DESCRIPTION
## Changes Summary

The checks `prompts/README.md` listed as manual steps, as code. Nothing else stands between a model and a student reading the word "wrong" in their feedback — the vocabulary rules are the product, not a style preference.

This is also what makes the model swappable. The hard/soft split means the model never discovers facts; it reframes structured input into a fixed shape. The failure mode of a small or local model is drift in exactly that shape. Small model + strong validator + one retry is a sound design; without the validator it is a bet on a model's mood.

### Specs come from the templates, not from the standard contract

Each mode carries its own `ResponseSpec`, read off what its template actually instructs:

| Mode | Headings differ how | Budget | Header |
|---|---|---|---|
| `STANDARD` | — | 400 | Velocity |
| `FIRST_SUBMISSION` | Welcome / Initial Velocity Reading / Foundation Elements / Growth Trajectory / Your Journey Begins | 400 | **Status** |
| `EMPTY_PR` | Submission Analysis / Possible Situations / Recommended Action | **200** | **Status** |
| `ALL_FAILING` | **"Growth Trajectory"**, plus a "Perspective" section | 400 | Velocity |
| `MASSIVE_PR` | **"Future Iteration Strategy"**, plus scale and limitation notices | 400 | Velocity |
| `SYNTAX_BARRIER` | Syntax Analysis / Barrier Details / What Happens Next | 400 | **Status** |
| `CONFIG_ONLY` | Submission Type / Algorithm Observations / Velocity Note | 400 | Velocity |

Modes replace one another. A test asserts no two modes share a heading set, because two modes with the same contract would mean one of them was transcribed from the wrong place.

Clearance overrides sit on top: INFRARED gets one opportunity; BLUE+ swaps `Recommended Iteration` for `Observations`, tightens to 250 words, and makes the celebration section optional.

### Two deliberate exemptions

Fenced blocks and inline code are exempt from the vocabulary rules and do not count toward the word budget. A response may legitimately quote `SyntaxError` from a tool report or show a student their own code; forbidding "error" inside a fence would reject correct output, and charging a quoted report against SHODANN's own word budget would punish it for showing evidence.

## Reviewed by both agents, and the second one earned its keep

First real fan-out — the two retargeted agents overlap nowhere.

**`oracle-warden` (haiku): `GATE PASS`.** All checks, plus an extra one I asked for: regex safety against pathological input, since these patterns run over untrusted model output. Unclosed fences, 10k-character lines, nested backticks — no catastrophic backtracking, timings captured.

**`clive-prompt-warden` (sonnet): four confirmed defects, none of which my 38 tests caught.** Each proven by running `validate()`, not by reading the code:

1. **Numbered lists bypassed the opportunity cap.** `_BULLET` matched `-`, `*`, `+` only. A response with five numbered growth opportunities validated clean — the exact cognitive-overload failure the cap exists to prevent. Not exotic: `prompts/05` uses numbered lists eleven times, so the model has every reason to copy that style.
2. **`CHARACTER_BREAKS` missed "I don't have feelings, but…"**, which `SHODANN_VOICE_GUIDE.md:400` names explicitly. Verified in the guide before fixing.
3. **BLUE+ still required the celebration section**, so a register-compliant peer response *failed* validation — forcing a retry that demands the maintainer manufacture praise for themselves. That is precisely the condescension `CLEARANCE_REGISTER.md` exists to prevent, and it is the more corrosive failure direction: good output rejected rather than bad output passed.
4. **BLUE+ *widened* `EMPTY_PR`'s budget** from 200 to 250, because the override set the cap unconditionally. BLUE+ is "shorter, not longer"; it may now only ever reduce a cap.

One extra fix from the same review: smart apostrophes are folded before matching, since a curly `’` was the cheapest available bypass of any phrase list.

## Related Issues

- Closes #24
- Relates to #18, #25, #28

## Component(s) Affected

- [ ] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [x] Persona/Voice System
- [ ] State Management
- [ ] Templates
- [ ] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 116 passed, 3 skipped, ruff clean. Every forbidden vocabulary row is parametrised, as is every list marker style and every character-break phrase. Both directions are tested: `badge` and `interrogation` must *not* trip the substring match, and a tool report quoted in a fence must not be rejected for containing `SyntaxError`.

Four regression tests were added directly from Clive's findings, each named for the failure it prevents rather than the function it calls.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

The module docstring records the two exemptions and why each exists, since both look like oversights until you know what they prevent.

## Educational Impact Assessment

### Student-Facing Changes

This is the last thing that runs before a comment posts, so its failures are student-visible by definition. Four of them were live in this PR before review: five concepts dumped in one review, SHODANN announcing it has no feelings, and — for a BLUE+ citizen — a bot insisting on praise before it would speak.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

The concept cap is a pedagogical rule, not a formatting one: `01` allows at most two growth opportunities because a beginner handed five improves none of them. That rule now has an enforcement point.

### Clearance Levels Affected

- [x] INFRARED (Complete beginner)
- [ ] RED (Junior)
- [ ] ORANGE (Mid-level)
- [ ] YELLOW (Senior)
- [ ] GREEN (Lead)
- [x] BLUE+ (Strategic)
- [ ] All levels

The two bands with overrides. GREEN was checked and correctly passes through unchanged.

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**Two findings recorded, not fixed:**

- `prompts/04` is internally inconsistent about its ending: the "Modified Response Format" block has one closer, and a later section headed "First Submission Closing" says *"always end first submission feedback with this format"* and defines a different `Welcome Aboard` section. The validator currently ignores the second. That is a template defect to resolve when `04` comes into scope, not a validator decision to make silently.
- The fence exemption is a theoretical hiding place: a model could put long or vocabulary-violating prose inside an unlabelled fence, which still renders as visible text to a student while escaping both the word cap and the vocabulary check. Not a defect today — the exemption is needed for quoting tool output — but it is the right subject for an adversarial-response test once a real model is generating.

**Retry policy lives here; the retry loop does not.** `format_retry_instruction` names the blocking violations and nothing else — restating the whole format layer tends to produce a response that fixes the wording and breaks the structure. Actually calling the model again, and falling back to a facts-only comment on a second failure, belongs to #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
