### PR TITLE
Post a review: single-job workflow, provider seam, degraded path

### DIFF
--- a/.github/workflows/shodann.yml
+++ b/.github/workflows/shodann.yml
@@ -1,0 +1,91 @@
+# =============================================================================
+# SHODANN: Educational Oversight Protocol - rung 1
+# =============================================================================
+#
+# One job, not the five the design describes. Five jobs on separate runners
+# have to push every tool report across a job boundary through $GITHUB_OUTPUT,
+# and any flake8 or pytest output containing a bare `EOF` line breaks the
+# heredoc delimiter. One job sidesteps that until there is a reason not to.
+#
+# SECURITY NOTE, and the reason this file does not resemble the draft in
+# design_docs/shodann-core.yml: no citizen-authored text is ever interpolated
+# into a `run:` block. The PR title and body reach Python as a parsed JSON
+# event payload and leave as a file. `${{ ... }}` interpolation of anything a
+# student can write would execute on a runner holding contents: write,
+# pull-requests: write and the model key.
+#
+# Trigger is `pull_request`, never `pull_request_target`. Topology is
+# org-owned repositories with branch pull requests (PRD section 8), so secrets
+# and a write token are available without the elevated trigger.
+# =============================================================================
+
+name: SHODANN Educational Oversight Protocol
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write        # persist the citizen ledger
+  pull-requests: write   # post the review comment
+
+concurrency:
+  # One review per pull request. A rapid push sequence should not race two
+  # jobs to write the same citizen file.
+  group: shodann-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: The Algorithm observes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out the submission
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install SHODANN
+        run: pip install --quiet .
+
+      - name: Compose the review
+        env:
+          # Citizen-controlled text never enters this step as an expression.
+          # Python reads the event payload from disk and parses it as JSON.
+          SHODANN_LLM_BASE_URL: ${{ vars.SHODANN_LLM_BASE_URL }}
+          SHODANN_LLM_MODEL: ${{ vars.SHODANN_LLM_MODEL }}
+          SHODANN_LLM_API_KEY: ${{ secrets.SHODANN_LLM_API_KEY }}
+        run: |
+          python -m shodann.review \
+            --event "$GITHUB_EVENT_PATH" \
+            --out shodann-comment.md \
+            --root .
+
+      - name: Post the review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr comment "$PR_NUMBER" --body-file shodann-comment.md
+
+      - name: Record the citizen ledger
+        env:
+          CITIZEN: ${{ github.event.pull_request.user.login }}
+        run: |
+          # $CITIZEN is a GitHub username: [A-Za-z0-9-] only, and quoted here
+          # regardless. It is used in a commit message, never in a path.
+          if [ -z "$(git status --porcelain .shodann)" ]; then
+            echo "No ledger change to record."
+            exit 0
+          fi
+          git config user.name  "shodann[bot]"
+          git config user.email "shodann[bot]@users.noreply.github.com"
+          git add .shodann
+          git commit -m "Record velocity for @${CITIZEN}"
+          git push origin "HEAD:${GITHUB_HEAD_REF}"

--- a/.shodann/citizens/norrisaftcc.json
+++ b/.shodann/citizens/norrisaftcc.json
@@ -1,0 +1,33 @@
+{
+  "citizen": "norrisaftcc",
+  "kind": "human",
+  "display": {
+    "visibility": "named",
+    "handle": null
+  },
+  "clearance_level": 2,
+  "first_submission": "2026-07-25T23:02:38Z",
+  "last_updated": "2026-07-25T23:02:38Z",
+  "baseline_established": true,
+  "pr_count": 1,
+  "iteration_streak": 1,
+  "rage_state_encounters": 0,
+  "last_metrics": {
+    "coverage": 0.0,
+    "test_count": 106,
+    "complexity": 277,
+    "loc": 5419,
+    "functions": 277,
+    "docstrings": 197,
+    "lint_issues": 0,
+    "syntax_errors": 0
+  },
+  "last_velocity": 401.28,
+  "velocity_trend": "new",
+  "velocity_history": [
+    {
+      "score": 401.28,
+      "date": "2026-07-25T23:02:38Z"
+    }
+  ]
+}

--- a/src/shodann/llm.py
+++ b/src/shodann/llm.py
@@ -22,7 +22,7 @@ import json
 import os
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 __all__ = ["LLMConfig", "LLMUnavailable", "generate"]
 
@@ -38,7 +38,14 @@ class LLMUnavailable(RuntimeError):
 class LLMConfig:
     base_url: str = ""
     model: str = ""
-    api_key: str = ""
+    api_key: str = field(default="", repr=False)
+    """Kept out of the auto-generated repr.
+
+    Nothing logs this object today, but a live secret in a dataclass is one
+    `logging.debug(config)` or one f-string typo away from a CI log that
+    anyone with read access can see. `describe()` is the safe accessor.
+    """
+
     timeout: int = DEFAULT_TIMEOUT
     max_tokens: int = DEFAULT_MAX_TOKENS
     temperature: float = 0.4

--- a/src/shodann/llm.py
+++ b/src/shodann/llm.py
@@ -1,0 +1,104 @@
+"""The one place SHODANN talks to a model.
+
+Job 4 is the only LLM consumer in the design, and its contract is narrow:
+assembled prompt in, under 400 words of markdown out. Everything upstream is
+deterministic tooling. That makes the provider a *configuration value* rather
+than an abstraction layer - which is the whole reason this file is twenty
+lines of HTTP and not a plugin system.
+
+One wire format is supported: OpenAI-compatible ``/chat/completions``. That is
+deliberate, and it is what makes local inference a config change rather than a
+port. Gemini publishes an OpenAI-compatible endpoint, and Ollama serves one
+natively, so swapping a hosted model for a laptop means editing a base URL and
+a model name.
+
+Nothing here retries on a bad *response* - that is the validator's job, and it
+knows what "bad" means. This retries on a flaky *connection* only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+__all__ = ["LLMConfig", "LLMUnavailable", "generate"]
+
+DEFAULT_TIMEOUT = 45
+DEFAULT_MAX_TOKENS = 900
+
+
+class LLMUnavailable(RuntimeError):
+    """No model could be reached. The caller degrades; it does not crash."""
+
+
+@dataclass(frozen=True)
+class LLMConfig:
+    base_url: str = ""
+    model: str = ""
+    api_key: str = ""
+    timeout: int = DEFAULT_TIMEOUT
+    max_tokens: int = DEFAULT_MAX_TOKENS
+    temperature: float = 0.4
+
+    @classmethod
+    def from_env(cls, environ: dict | None = None) -> LLMConfig:
+        env = environ if environ is not None else os.environ
+        return cls(
+            base_url=env.get("SHODANN_LLM_BASE_URL", "").rstrip("/"),
+            model=env.get("SHODANN_LLM_MODEL", ""),
+            api_key=env.get("SHODANN_LLM_API_KEY", ""),
+            timeout=int(env.get("SHODANN_LLM_TIMEOUT", DEFAULT_TIMEOUT)),
+        )
+
+    @property
+    def configured(self) -> bool:
+        """A local endpoint needs no key; a hosted one does. Both need a URL and a model."""
+        return bool(self.base_url and self.model)
+
+    def describe(self) -> str:
+        """Safe for logs. Never includes the key."""
+        return f"{self.model} at {self.base_url}" if self.configured else "not configured"
+
+
+def generate(prompt: str, config: LLMConfig, *, opener=urllib.request.urlopen) -> str:
+    """Send one prompt, return the model's text.
+
+    ``opener`` is injectable so the whole path is testable without a network
+    or a key - which matters, because the degraded path is the one that runs
+    when a student most needs feedback.
+    """
+    if not config.configured:
+        raise LLMUnavailable("no model configured")
+
+    payload = json.dumps(
+        {
+            "model": config.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": config.max_tokens,
+            "temperature": config.temperature,
+        }
+    ).encode("utf-8")
+
+    headers = {"Content-Type": "application/json"}
+    if config.api_key:
+        headers["Authorization"] = f"Bearer {config.api_key}"
+
+    request = urllib.request.Request(  # noqa: S310 - scheme is operator config, not user input
+        f"{config.base_url}/chat/completions", data=payload, headers=headers, method="POST"
+    )
+
+    try:
+        with opener(request, timeout=config.timeout) as response:
+            body = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        raise LLMUnavailable(f"{config.describe()} unreachable: {error}") from error
+    except json.JSONDecodeError as error:
+        raise LLMUnavailable(f"{config.describe()} returned unparseable JSON") from error
+
+    try:
+        return body["choices"][0]["message"]["content"].strip()
+    except (KeyError, IndexError, TypeError, AttributeError) as error:
+        raise LLMUnavailable(f"{config.describe()} returned an unexpected shape") from error

--- a/src/shodann/review.py
+++ b/src/shodann/review.py
@@ -1,0 +1,230 @@
+"""One review, end to end: facts in, a comment body out.
+
+This is rung 1 - the walking skeleton. It runs as a single job rather than the
+five-job pipeline the design describes, because five jobs on separate runners
+need every tool report to cross a job boundary through ``$GITHUB_OUTPUT``, and
+any flake8 or pytest output containing a bare ``EOF`` line breaks the
+delimiter. One job sidesteps that entirely until there is a reason not to.
+
+**Nothing here reads a PR title or body into a shell.** Untrusted text arrives
+as a parsed JSON event payload and leaves as a file written by Python. The
+workflow never interpolates it into a ``run:`` block, which is the defect the
+draft workflow in ``design_docs/shodann-core.yml`` carries at line 131.
+
+The degraded path is the interesting one. If no model is configured, or the
+model is unreachable, or its output cannot be made to satisfy the contract in
+one retry, a student still receives a comment - assembled from the tool facts
+alone, in SHODANN's voice, and validated like any other.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .llm import LLMConfig, LLMUnavailable, generate
+from .prompts import build_context, render_prompt
+from .state import CitizenRecord, clearance_name, load_citizen_history, save_citizen_history
+from .validator import (
+    SPECS,
+    ResponseSpec,
+    blocks_posting,
+    for_clearance,
+    format_retry_instruction,
+    validate,
+)
+from .velocity import CodeMetrics, VelocityResult, calculate_velocity
+
+__all__ = ["collect_metrics", "facts_only_comment", "main", "pr_facts", "review"]
+
+
+def pr_facts(event: dict) -> dict:
+    """Pull the submission facts out of a GitHub pull_request event payload."""
+    pull = event.get("pull_request") or {}
+    user = pull.get("user") or {}
+    return {
+        "citizen": user.get("login") or "unknown-citizen",
+        "number": pull.get("number") or 0,
+        "title": pull.get("title") or "(untitled)",
+        "files_changed": pull.get("changed_files") or 0,
+        "lines_added": pull.get("additions") or 0,
+        "lines_removed": pull.get("deletions") or 0,
+        "commits": pull.get("commits") or 1,
+    }
+
+
+def collect_metrics(root: Path | str = ".") -> CodeMetrics:
+    """Count what can be counted without running anything.
+
+    Rung 1 deliberately runs no analysis tools. Reading source is cheap, needs
+    no toolchain, and cannot execute a student's code - which matters more
+    than the extra signal a test run would add. Coverage stays zero until the
+    hard-analysis job exists, so velocity here is carried by test growth,
+    documentation and iteration count.
+    """
+    loc = tests = functions = docstrings = 0
+    for path in sorted(Path(root).rglob("*.py")):
+        if any(part in {".venv", "node_modules", ".git"} for part in path.parts):
+            continue
+        try:
+            body = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        loc += len(body.splitlines())
+        tests += body.count("def test_")
+        functions += body.count("def ")
+        docstrings += body.count('"""') // 2
+
+    return CodeMetrics(
+        coverage=0.0,
+        test_count=tests,
+        complexity=functions,
+        loc=loc,
+        functions=functions,
+        docstrings=docstrings,
+    )
+
+
+def facts_only_comment(
+    facts: dict, result: VelocityResult, record: CitizenRecord, reason: str
+) -> str:
+    """The comment a citizen gets when no model could be reached.
+
+    PRD section 8 commits to graceful degradation: a student always receives
+    *some* feedback. This is that floor, and it honours the same output
+    contract as a generated response - it is quieter, not lesser.
+    """
+    celebrations = "\n".join(f"- {line}" for line in result.celebrations[:3])
+    opportunities = "\n".join(f"- {line}" for line in result.opportunities) or (
+        "- The Algorithm has no growth opportunities to raise this iteration."
+    )
+    next_step = (
+        "Keep the iteration cadence. The Algorithm will have more to say once "
+        "the analysis tools are online."
+    )
+
+    return f"""## \U0001f916 SHODANN Analysis Complete
+
+**Citizen**: @{facts["citizen"]} | **Clearance**: {clearance_name(record.clearance_level)} | \
+**Velocity**: {result.score}
+
+---
+
+### \U0001f680 Shipping Velocity Report
+
+{result.assessment}. Submission {record.pr_count} across {result.iterations} \
+commit(s), touching {facts["files_changed"]} file(s).
+
+### ✅ Algorithm-Approved Patterns
+
+{celebrations}
+
+### \U0001f4c8 Growth Opportunities
+
+{opportunities}
+
+### \U0001f527 Recommended Iteration
+
+{next_step}
+
+---
+
+*The Algorithm sees your growth. The Algorithm is pleased.*
+
+<sub>Generated without model synthesis ({reason}).</sub>
+"""
+
+
+def _spec_for(record: CitizenRecord, mode: str) -> ResponseSpec:
+    return for_clearance(SPECS[mode], record.clearance_level)
+
+
+def _synthesise(
+    prompt: str, spec: ResponseSpec, config: LLMConfig, opener=None
+) -> str:
+    """Generate, validate, retry once naming the violations, then give up.
+
+    Giving up is not failure - it hands control back to the caller, which has
+    a comment ready that does not need a model at all.
+    """
+    transport = {"opener": opener} if opener is not None else {}
+
+    response = generate(prompt, config, **transport)
+    violations = validate(response, spec)
+    if not blocks_posting(violations):
+        return response
+
+    retry = f"{prompt}\n\n{format_retry_instruction(violations)}"
+    second = generate(retry, config, **transport)
+    if blocks_posting(validate(second, spec)):
+        raise LLMUnavailable("response violated the output contract twice")
+    return second
+
+
+def review(
+    event: dict,
+    *,
+    root: Path | str = ".",
+    config: LLMConfig | None = None,
+    mode: str = "standard",
+    opener=None,
+    write_state: bool = True,
+) -> str:
+    """Produce the comment body for one pull request."""
+    facts = pr_facts(event)
+    config = config or LLMConfig.from_env()
+
+    record = load_citizen_history(facts["citizen"], root)
+    metrics = collect_metrics(root)
+    result = calculate_velocity(metrics, record.last_metrics, facts["commits"])
+
+    if write_state:
+        record = save_citizen_history(facts["citizen"], metrics, result, root)
+    else:
+        record.pr_count += 1
+
+    spec = _spec_for(record, mode)
+
+    try:
+        context = build_context(
+            result,
+            record,
+            pr_title=facts["title"],
+            files_changed=facts["files_changed"],
+            lines_added=facts["lines_added"],
+            lines_removed=facts["lines_removed"],
+        )
+        # Note the asymmetry: `root` is the citizen's repository, but the
+        # prompt library is SHODANN's own and is read relative to the working
+        # directory. Rung 1 reviews this repository, so they coincide. They
+        # will not once SHODANN reviews someone else's repo, and at that point
+        # the templates need to ship as package data.
+        prompt = render_prompt(context)
+        return _synthesise(prompt, spec, config, opener=opener)
+    except LLMUnavailable as unavailable:
+        return facts_only_comment(facts, result, record, str(unavailable))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="shodann-review")
+    parser.add_argument("--event", required=True, help="path to the GitHub event payload")
+    parser.add_argument("--out", required=True, help="where to write the comment body")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--mode", default="standard", choices=sorted(SPECS))
+    args = parser.parse_args(argv)
+
+    with Path(args.event).open(encoding="utf-8") as handle:
+        event = json.load(handle)
+
+    body = review(event, root=args.root, mode=args.mode)
+    Path(args.out).write_text(body, encoding="utf-8")
+
+    # Never echo the body: it contains citizen-authored text via the PR title.
+    sys.stderr.write(f"SHODANN wrote {len(body.split())} words to {args.out}\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -202,6 +202,14 @@ def test_the_key_never_appears_in_a_description() -> None:
     assert "super-secret" not in config.describe()
 
 
+def test_the_key_never_appears_in_the_repr_either() -> None:
+    """One logging.debug(config) away from a CI log anyone can read."""
+    config = LLMConfig(base_url="http://x/v1", model="m", api_key="super-secret")
+
+    assert "super-secret" not in repr(config)
+    assert "super-secret" not in f"{config}"
+
+
 def test_a_malformed_response_shape_degrades(tmp_path) -> None:
     def wrong_shape(request, timeout=None):
         return FakeResponse(json.dumps({"unexpected": True}).encode("utf-8"))

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,238 @@
+"""One review, end to end - especially the paths that run when things go wrong."""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from shodann.llm import LLMConfig, LLMUnavailable, generate
+from shodann.review import collect_metrics, main, pr_facts, review
+from shodann.state import citizen_path, load_citizen_history
+from shodann.validator import STANDARD, blocks_posting, validate
+
+EVENT = {
+    "pull_request": {
+        "number": 42,
+        "title": "Add inventory tests",
+        "changed_files": 4,
+        "additions": 120,
+        "deletions": 18,
+        "commits": 3,
+        "user": {"login": "octocat"},
+    }
+}
+
+GOOD_RESPONSE = """## \U0001f916 SHODANN Analysis Complete
+
+**Citizen**: @octocat | **Clearance**: RED | **Velocity**: 9.0
+
+### \U0001f680 Shipping Velocity Report
+
+Four files moved and three commits landed. The Algorithm has observed steady progress.
+
+### ✅ Algorithm-Approved Patterns
+
+- Tests arrived with the feature.
+
+### \U0001f4c8 Growth Opportunities
+
+- The Algorithm suggests naming the helper for what it returns.
+
+### \U0001f527 Recommended Iteration
+
+Add one test for the empty branch.
+
+*The Algorithm sees your growth. The Algorithm is pleased.*
+"""
+
+
+class FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def responder(*bodies: str):
+    """An opener that returns each body in turn, recording the prompts it saw."""
+    seen: list[str] = []
+    remaining = list(bodies)
+
+    def opener(request, timeout=None):
+        seen.append(json.loads(request.data)["messages"][0]["content"])
+        payload = {"choices": [{"message": {"content": remaining.pop(0)}}]}
+        return FakeResponse(json.dumps(payload).encode("utf-8"))
+
+    opener.seen = seen
+    return opener
+
+
+CONFIG = LLMConfig(base_url="http://model.invalid/v1", model="test-model", api_key="k")
+
+
+# --- payload handling -----------------------------------------------------
+
+
+def test_facts_are_read_from_the_payload_not_the_shell() -> None:
+    facts = pr_facts(EVENT)
+    assert facts["citizen"] == "octocat"
+    assert facts["commits"] == 3
+    assert facts["title"] == "Add inventory tests"
+
+
+def test_a_hostile_pr_title_is_just_a_string() -> None:
+    """The title reaches Python as data. There is no shell for it to reach."""
+    hostile = {"pull_request": {**EVENT["pull_request"], "title": "$(rm -rf /) `whoami`"}}
+    assert pr_facts(hostile)["title"] == "$(rm -rf /) `whoami`"
+
+
+def test_a_sparse_payload_does_not_crash() -> None:
+    facts = pr_facts({"pull_request": {}})
+    assert facts["citizen"] == "unknown-citizen"
+    assert facts["commits"] == 1
+
+
+# --- metrics --------------------------------------------------------------
+
+
+def test_metrics_ignore_the_virtualenv(tmp_path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "thing.py").write_text(
+        'def one():\n    """Doc."""\n    return 1\n', encoding="utf-8"
+    )
+    venv = tmp_path / ".venv" / "lib"
+    venv.mkdir(parents=True)
+    (venv / "vendored.py").write_text("def " * 500, encoding="utf-8")
+
+    metrics = collect_metrics(tmp_path)
+    assert metrics.functions == 1
+    assert metrics.docstrings == 1
+    assert metrics.coverage == 0.0, "rung 1 runs no coverage tool and must not pretend otherwise"
+
+
+# --- the happy path -------------------------------------------------------
+
+
+def test_a_valid_response_is_posted_as_is(tmp_path) -> None:
+    opener = responder(GOOD_RESPONSE)
+    body = review(EVENT, root=tmp_path, config=CONFIG, opener=opener)
+
+    assert body == GOOD_RESPONSE.strip(), "surrounding whitespace is trimmed"
+    assert len(opener.seen) == 1, "no retry needed"
+
+
+def test_state_is_recorded(tmp_path) -> None:
+    review(EVENT, root=tmp_path, config=CONFIG, opener=responder(GOOD_RESPONSE))
+
+    record = load_citizen_history("octocat", tmp_path)
+    assert record.pr_count == 1
+    assert citizen_path("octocat", tmp_path).exists()
+
+
+# --- retry ----------------------------------------------------------------
+
+
+def test_a_contract_violation_is_retried_once_with_the_violations_named(tmp_path) -> None:
+    bad = GOOD_RESPONSE.replace("The Algorithm suggests naming", "You should rename")
+    opener = responder(bad, GOOD_RESPONSE)
+
+    body = review(EVENT, root=tmp_path, config=CONFIG, opener=opener)
+
+    assert body == GOOD_RESPONSE.strip(), "surrounding whitespace is trimmed"
+    assert len(opener.seen) == 2
+    assert "the Algorithm suggests" in opener.seen[1], "the retry must name the violation"
+
+
+def test_two_bad_responses_fall_back_rather_than_posting_the_second(tmp_path) -> None:
+    bad = GOOD_RESPONSE.replace("The Algorithm suggests naming", "You should rename")
+    body = review(EVENT, root=tmp_path, config=CONFIG, opener=responder(bad, bad))
+
+    assert "You should" not in body
+    assert "Generated without model synthesis" in body
+
+
+# --- degradation ----------------------------------------------------------
+
+
+def test_no_model_configured_still_produces_a_comment(tmp_path) -> None:
+    """PRD section 8: a student always receives some feedback."""
+    body = review(EVENT, root=tmp_path, config=LLMConfig())
+
+    assert "SHODANN Analysis Complete" in body
+    assert "@octocat" in body
+    assert "no model configured" in body
+
+
+def test_an_unreachable_model_still_produces_a_comment(tmp_path) -> None:
+    def refuse(request, timeout=None):
+        raise OSError("connection refused")
+
+    body = review(EVENT, root=tmp_path, config=CONFIG, opener=refuse)
+    assert "SHODANN Analysis Complete" in body
+
+
+def test_the_fallback_comment_honours_the_output_contract(tmp_path) -> None:
+    """The degraded path is quieter, not lesser. It passes the same validator."""
+    body = review(EVENT, root=tmp_path, config=LLMConfig())
+    violations = validate(body, STANDARD)
+
+    assert not blocks_posting(violations), [str(v) for v in violations]
+
+
+def test_the_fallback_never_uses_forbidden_vocabulary(tmp_path) -> None:
+    body = review(EVENT, root=tmp_path, config=LLMConfig())
+    lowered = body.lower()
+    for forbidden in ("wrong", "failed", "mistake", "unfortunately"):
+        assert forbidden not in lowered
+
+
+# --- the llm client -------------------------------------------------------
+
+
+def test_an_unconfigured_client_raises_rather_than_guessing() -> None:
+    with pytest.raises(LLMUnavailable, match="no model configured"):
+        generate("prompt", LLMConfig())
+
+
+def test_the_key_never_appears_in_a_description() -> None:
+    config = LLMConfig(base_url="http://x/v1", model="m", api_key="super-secret")
+    assert "super-secret" not in config.describe()
+
+
+def test_a_malformed_response_shape_degrades(tmp_path) -> None:
+    def wrong_shape(request, timeout=None):
+        return FakeResponse(json.dumps({"unexpected": True}).encode("utf-8"))
+
+    with pytest.raises(LLMUnavailable, match="unexpected shape"):
+        generate("prompt", CONFIG, opener=wrong_shape)
+
+
+def test_config_reads_the_environment() -> None:
+    config = LLMConfig.from_env(
+        {
+            "SHODANN_LLM_BASE_URL": "http://localhost:11434/v1/",
+            "SHODANN_LLM_MODEL": "llama3.2",
+        }
+    )
+    assert config.base_url == "http://localhost:11434/v1", "trailing slash trimmed"
+    assert config.configured, "a local endpoint needs no api key"
+
+
+# --- cli ------------------------------------------------------------------
+
+
+def test_cli_writes_the_body_to_a_file_and_not_to_stdout(tmp_path, capsys) -> None:
+    """The body carries a citizen-authored title; it must not be echoed into a log."""
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(EVENT), encoding="utf-8")
+    out = tmp_path / "comment.md"
+
+    assert main(["--event", str(event_file), "--out", str(out), "--root", str(tmp_path)]) == 0
+
+    captured = capsys.readouterr()
+    assert "SHODANN Analysis Complete" in out.read_text(encoding="utf-8")
+    assert "SHODANN Analysis Complete" not in captured.out
+    assert "wrote" in captured.err


### PR DESCRIPTION
## Changes Summary

Rung 1's deliverable: one job, on this repository's own pull requests, that posts one SHODANN comment. **This PR creates the repository's first GitHub Actions workflow** — it converts a documentation repo into one that executes on every PR, holding `contents: write`, `pull-requests: write`, and a model key.

| File | Role |
|---|---|
| `.github/workflows/shodann.yml` | Single job. Renders, generates, validates, posts, records. |
| `src/shodann/llm.py` | The provider seam — one wire format, config-only swapping. |
| `src/shodann/review.py` | One review end to end, including every way it can degrade. |

### Deliberately unlike the draft workflow

`design_docs/shodann-core.yml:131` interpolates the PR body straight into a `run:` block. Here, **no citizen-authored text is interpolated into a shell at all.** The title and body reach Python as a parsed JSON event payload and leave as a file, posted with `gh pr comment --body-file`. Every `${{ }}` expression in the file lands in an `env:` mapping or a `concurrency` key; none reach a `run:` script body.

Also: `pull_request`, never `pull_request_target`. Because the topology decided in #19 is org-owned repos with branch PRs, secrets and a write token are available without the elevated trigger — so we never go near the `checkout` fork-head restriction.

**One job, not five.** Five jobs on separate runners have to push whole tool reports across boundaries through `$GITHUB_OUTPUT` heredocs, and any pytest output containing a bare `EOF` line breaks the delimiter. One job sidesteps that until there is a reason not to.

### The provider seam (#26)

`llm.py` speaks **OpenAI-compatible chat completions and nothing else.** That is the design, not a limitation: Gemini publishes a compatible endpoint and Ollama serves one natively, so moving from a hosted model to a laptop is a base URL and a model name. `SHODANN_LLM_BASE_URL` + `SHODANN_LLM_MODEL` + optionally `SHODANN_LLM_API_KEY` — a local endpoint needs no key, and `configured` knows that.

### The degraded path is the one that matters

If no model is configured, or it is unreachable, or its output violates the contract twice, a citizen **still gets a comment** — assembled from tool facts alone, in SHODANN's voice, and passing the same validator as a generated response. `PRD.md` §8 promises some feedback always; this is that floor, and it is tested harder than the happy path.

Retry policy: one retry naming the specific violations, then fall back. Not two, not a loop.

## Related Issues

- Closes #25
- Closes #26

## Component(s) Affected

- [x] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [x] Persona/Voice System
- [x] State Management
- [ ] Templates
- [ ] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 134 passed, 3 skipped, ruff clean.

Gated by `oracle-warden` with six additional security checks for this change specifically. **`GATE PASS`, 12/12**, one latent defect reported and fixed in a follow-up commit. Highlights, all proven by execution rather than by reading:

- **Injection, end to end.** An event payload whose PR title contains `$(id)`, backticks and a newline was run through the CLI into a temp directory. Process exits 0, no substitution occurs, the title survives byte-for-byte into the output file as literal text, and `git status` on the repo stays clean.
- **Every `${{ }}` enumerated** and classified by whether the value is attacker-controlled and whether it reaches a `run:` body. Seven expressions, none in a script.
- **Secret handling.** The key reaches only the step that needs it, appears in no command line, and is never written to disk.
- **Degraded path.** With no model configured, a comment is still produced and passes `validate()` against the STANDARD spec.

**The one defect it found, now fixed:** `LLMConfig` was a plain frozen dataclass, so `repr()` and `f"{config}"` contained the API key in plaintext. `describe()` correctly omitted it and no current call site logs the object — but a live secret in an auto-generated repr is one `logging.debug(config)` or one f-string typo away from a CI log anyone with read access can see. The field now carries `repr=False`, with a test asserting both `repr()` and f-string interpolation stay clean.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

The workflow's header comment records why it does not resemble the draft, and `review.py`'s docstring records why one job rather than five.

## Educational Impact Assessment

### Student-Facing Changes

**This is the first PR whose output a student would actually read.** Everything before it built parts; this one posts a comment.

The visible behaviour: a citizen opening a PR gets a SHODANN comment within the job's runtime. If the model is down they still get one — quieter, assembled from facts, carrying a small note that synthesis was unavailable rather than pretending otherwise.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

The fallback comment was written to pass its own validator, and a test asserts it — the degraded path is quieter, not lesser, and it does not get to skip the vocabulary rules because it was assembled in a hurry.

### Clearance Levels Affected

- [ ] INFRARED (Complete beginner)
- [ ] RED (Junior)
- [ ] ORANGE (Mid-level)
- [ ] YELLOW (Senior)
- [ ] GREEN (Lead)
- [ ] BLUE+ (Strategic)
- [x] All levels
- [ ] Not student-facing

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**Two action versions want confirming on first run.** `actions/checkout@v7` and `actions/setup-python@v6` are what current research indicates, but neither was verifiable from here. If the first run fails on a resolution error, that is why.

**Rung 1 runs no analysis tools.** `collect_metrics` reads source and counts `def test_`, `def `, and docstrings. It never executes a student's code, which matters more than the extra signal a test run would add. Coverage stays zero until the hard-analysis job exists, so velocity here is carried by test growth, documentation and iteration count — and the fallback comment says so.

**One asymmetry worth knowing about:** `root` is the citizen's repository, but the prompt library is SHODANN's own and is read relative to the working directory. Rung 1 reviews *this* repository, so they coincide. They will not once SHODANN reviews someone else's repo, and at that point the templates need to ship as package data. Noted in the code at the point where it matters.

**Merging this arms the workflow.** The next PR opened against this repository will be reviewed by SHODANN — which is the point, and is also worth saying out loud before it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
