### PR TITLE
Partition the leaderboard by kind, and gate agent data at ORANGE

### DIFF
--- a/.shodann/citizens/norrisaftcc.json
+++ b/.shodann/citizens/norrisaftcc.json
@@ -7,24 +7,28 @@
   },
   "clearance_level": 2,
   "first_submission": "2026-07-25T23:08:59Z",
-  "last_updated": "2026-07-25T23:08:59Z",
+  "last_updated": "2026-07-25T23:14:09Z",
   "baseline_established": true,
-  "pr_count": 1,
-  "iteration_streak": 1,
+  "pr_count": 2,
+  "iteration_streak": 2,
   "rage_state_encounters": 0,
   "last_metrics": {
     "coverage": 0.0,
-    "test_count": 110,
-    "complexity": 204,
-    "loc": 3436,
-    "functions": 204,
-    "docstrings": 127,
+    "test_count": 117,
+    "complexity": 214,
+    "loc": 3577,
+    "functions": 214,
+    "docstrings": 133,
     "lint_issues": 0,
     "syntax_errors": 0
   },
-  "last_velocity": 328.3,
-  "velocity_trend": "new",
+  "last_velocity": 18.8,
+  "velocity_trend": "descending",
   "velocity_history": [
+    {
+      "score": 18.8,
+      "date": "2026-07-25T23:14:09Z"
+    },
     {
       "score": 328.3,
       "date": "2026-07-25T23:08:59Z"

--- a/design_docs/LEADERBOARD.md
+++ b/design_docs/LEADERBOARD.md
@@ -1,0 +1,79 @@
+# Leaderboard: The Partition Rule
+
+> **Status**: Design decision, 2026-07-25
+> **Scope**: How citizens are ranked against each other, and who is never ranked against whom
+> **Depends on**: `PRD.md` §5 US-3.2 (leaderboard requirements), §7 (no ranking by absolute skill), §8 Decisions (opt-in naming, `kind` discriminator)
+
+---
+
+## The rule
+
+**Leaderboards partition by `kind`. A human citizen sees human citizens. An agent board exists separately. There is no default combined view.**
+
+Not a filter applied to a combined board. A partition: the board you are looking at is always *one kind*, and which one is a decision you made before you got there.
+
+## Why: walking is not driving
+
+Choose walking in a maps application and the estimate is an hour. Choose driving and it is twelve minutes. Nobody looks at that and concludes they are a bad walker. The application never presents one ranked list of arrival times with pedestrians at the bottom, because the mode is the first thing you pick and everything after it is scoped to that choice.
+
+Same unit. Same destination. Meaningless comparison.
+
+An agent that ships eight hundred lines an hour and a student writing their first test are in different modes. Both produce a velocity number, and the numbers are even computed by the same engine — which is exactly what makes the mistake easy to build and hard to see.
+
+## Why it matters more here than it would elsewhere
+
+A first-week student has **no reference frame**. That is the whole reason this system measures the derivative instead of the position: a beginner cannot tell whether 30% coverage is good, but they can tell whether it went up. Absolute position is the one signal they are unable to calibrate, so we do not ask them to.
+
+Ranking that student below an agent hands them an uncalibrated comparison — delivered, with a number attached, by the system built specifically to prevent uncalibrated comparison. It is `PRD.md` §7's prohibition on ranking by absolute skill, arriving through a side door.
+
+The failure is quiet, too. Nobody files a bug saying "the leaderboard made me feel like I should not be here."
+
+## A second, independent reason
+
+Even setting the pedagogy aside, the numbers are not commensurable.
+
+Agent velocity is a different metric set — throughput, revision count, how often output survives review. Student velocity is coverage delta, test growth, documentation, iteration. Running both through `calculate_velocity` produces two floats that share a name and measure different things. Combining them would be a unit error dressed up as a ranking.
+
+Two independent reasons to partition means the rule survives even if someone later decides the pedagogical argument is overcautious.
+
+## The agent board is ORANGE and up
+
+**Minimum clearance to see agent data at all: ORANGE (3).** INFRARED and RED citizens are not shown the agent board, and are not shown that it exists.
+
+This follows the same logic as the partition itself, one step further. The partition stops a beginner being *ranked* against an agent; the clearance gate stops them being handed the comparison at all. At INFRARED and RED a citizen is still assembling a reference frame — that is what those bands mean. Agent throughput is not information they can use, and it is information they can be discouraged by.
+
+By ORANGE a citizen has enough context to read an agent's numbers as a different mode rather than as a verdict. That is also roughly the band where working alongside an agent starts being a professional skill worth making legible instead of a distraction worth deferring.
+
+The gate is on the *viewer*, not the data. Nothing about the agent record is secret; the record is in the repository like every other citizen's. What is gated is putting the comparison in front of someone who has no way to calibrate it.
+
+## What the combined view is for
+
+It exists, and it is a specialist instrument: agent-fleet throughput analysis, instructor reporting, cost-per-review evidence for a budget conversation.
+
+Requirements when it is built:
+
+- Reached deliberately, never as a default or a landing page.
+- Gated at ORANGE, like the agent board it contains.
+- Labelled as a mixed-kind view at the top, in the document itself, not only in the navigation that led there.
+- Never the artifact called `METRICS.md`. That name belongs to the citizen board.
+
+Nobody opens the combined board without already wanting agent data. If someone lands there by accident, the design is wrong.
+
+## This is not hiding the agents
+
+Agents are citizens in the registry, carry `kind: "agent"`, and get their own visible board. A course where students collaborate with coding agents and the agents are invisible in the record would be dishonest about how the work actually happened.
+
+Visible, separate, and comparable within kind. The comparison a student should be able to make about an agent is *what did it do*, not *did it beat me*.
+
+## Consequences for implementation
+
+- `generate_leaderboard` takes a `kind` and defaults to `human`. A mixed board requires passing `kind=None` explicitly, and the rendered document says so in its subtitle.
+- Any request for a non-human board carries the viewer's clearance and is refused below ORANGE. Refused loudly, at generation time — not rendered and then hidden by a template, which leaves the data one view-source away.
+- `kind` is the partition key, so it must be present on every record. The schema defaults it to `human`, and a record that somehow lacks it partitions as human rather than vanishing.
+- Sorting happens *after* partitioning, never before. A single sorted list that is later filtered is the same bug with extra steps — the ranks come out of the wrong denominator.
+- The opt-in display rules (`PRD.md` §8) apply to every board independently. An anonymous citizen is anonymous on the agent-inclusive view too.
+- `PRD.md` US-3.2's "all citizens appear after first submission" is scoped to the board's own kind. Every human appears on the human board.
+
+## What this does not decide
+
+Whether agent velocity should use the same engine at all, and what an agent's metric set contains. Both are open, and both are downstream of someone actually wanting agent metrics for something.

--- a/src/shodann/leaderboard.py
+++ b/src/shodann/leaderboard.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 from .state import (
     CITIZENS_DIR,
+    KIND_AGENT,
+    KIND_HUMAN,
     TREND_ASCENDING,
     TREND_DESCENDING,
     TREND_NEW,
@@ -24,7 +26,19 @@ from .state import (
     CitizenRecord,
 )
 
-__all__ = ["generate_leaderboard", "load_all_citizens"]
+__all__ = [
+    "AGENT_VIEW_MIN_CLEARANCE",
+    "ClearanceRequired",
+    "generate_leaderboard",
+    "load_all_citizens",
+    "may_view",
+]
+
+
+def _board_name(kind: str | None) -> str:
+    if kind == KIND_AGENT:
+        return "Agent Fleet"
+    return "All Citizens" if kind is None else str(kind).title()
 
 TREND_GLYPHS = {
     TREND_ASCENDING: "\U0001f4c8",
@@ -60,21 +74,63 @@ def load_all_citizens(root: Path | str = ".") -> list[CitizenRecord]:
     return records
 
 
-def generate_leaderboard(root: Path | str = ".", *, generated_at: str | None = None) -> str:
-    """Render the full leaderboard as markdown.
+AGENT_VIEW_MIN_CLEARANCE = 3
+"""ORANGE. Below it, a citizen is not shown agent data and is not shown that it exists."""
+
+
+class ClearanceRequired(PermissionError):
+    """A viewer asked for a board their band does not open."""
+
+
+def may_view(kind: str | None, clearance: int) -> bool:
+    """Whether a citizen at ``clearance`` may open a board of ``kind``."""
+    return kind == KIND_HUMAN or clearance >= AGENT_VIEW_MIN_CLEARANCE
+
+
+def generate_leaderboard(
+    root: Path | str = ".",
+    *,
+    kind: str | None = KIND_HUMAN,
+    viewer_clearance: int | None = None,
+    generated_at: str | None = None,
+) -> str:
+    """Render one board as markdown.
+
+    Boards partition by ``kind`` - see design_docs/LEADERBOARD.md. A human
+    citizen and an agent are in different modes, the way walking and driving
+    are different modes: same units, same destination, meaningless comparison.
+    Pass ``kind=None`` for the mixed view, which is a specialist instrument
+    and never the default.
 
     Returns the document even when there are no citizens yet - an empty course
     is a valid state, not an error worth exiting on.
     """
+    if viewer_clearance is not None and not may_view(kind, viewer_clearance):
+        raise ClearanceRequired(
+            f"agent data requires clearance {AGENT_VIEW_MIN_CLEARANCE} (ORANGE); "
+            f"viewer holds {viewer_clearance}"
+        )
+
     records = load_all_citizens(root)
+    if kind is not None:
+        # Partition first, then rank. Ranking a mixed list and filtering
+        # afterwards produces the right names against the wrong denominator.
+        records = [record for record in records if record.kind == kind]
     records.sort(key=lambda record: record.last_velocity, reverse=True)
 
     lines = [
-        HEADER,
+        HEADER if kind == KIND_HUMAN else f"{HEADER} - {_board_name(kind)}",
         "",
         "> *The Algorithm celebrates those who grow, not those who rest.*",
         "",
     ]
+    if kind is None:
+        lines += [
+            "**Mixed-kind view.** Human citizens and agents appear in one ranking here. "
+            "They are not comparable; this board exists for fleet analysis, not for "
+            "assessment. See `design_docs/LEADERBOARD.md`.",
+            "",
+        ]
     if generated_at:
         lines += [f"**Last Updated**: {generated_at}", ""]
 

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -4,8 +4,16 @@ from __future__ import annotations
 
 import json
 
-from shodann.leaderboard import generate_leaderboard, load_all_citizens
-from shodann.state import VISIBILITY_ANONYMOUS, CitizenRecord, Display, citizen_path
+import pytest
+
+from shodann.leaderboard import ClearanceRequired, generate_leaderboard, load_all_citizens
+from shodann.state import (
+    KIND_AGENT,
+    VISIBILITY_ANONYMOUS,
+    CitizenRecord,
+    Display,
+    citizen_path,
+)
 
 
 def write_record(root, citizen, velocity, *, anonymous=False, handle=None, pr_count=1):
@@ -52,6 +60,83 @@ def test_anonymous_citizens_appear_without_their_username(tmp_path) -> None:
 
     assert "Citizen-7" in document
     assert "shyperson" not in document
+
+
+# --- the partition rule ---------------------------------------------------
+
+
+def write_agent(root, name, velocity):
+    record = CitizenRecord(citizen=name, kind=KIND_AGENT, last_velocity=velocity, pr_count=9)
+    path = citizen_path(name, root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record.to_dict()), encoding="utf-8")
+
+
+def test_agents_never_appear_on_the_citizen_board(tmp_path) -> None:
+    """Walking is not driving. An agent shipping fast is a different mode."""
+    write_record(tmp_path, "student", 4.0)
+    write_agent(tmp_path, "oracle-warden", 900.0)
+
+    document = generate_leaderboard(tmp_path)
+
+    assert "@student" in document
+    assert "oracle-warden" not in document
+    assert "| 1 |" in document and "@student" in document.splitlines()[
+        next(i for i, line in enumerate(document.splitlines()) if line.startswith("| 1 "))
+    ], "the student is rank 1 of humans, not rank 2 of everything"
+
+
+def test_the_agent_board_is_its_own_document(tmp_path) -> None:
+    write_record(tmp_path, "student", 4.0)
+    write_agent(tmp_path, "oracle-warden", 900.0)
+
+    document = generate_leaderboard(tmp_path, kind=KIND_AGENT)
+
+    assert "oracle-warden" in document
+    assert "@student" not in document
+    assert "Agent Fleet" in document
+
+
+def test_the_mixed_view_says_what_it_is(tmp_path) -> None:
+    write_record(tmp_path, "student", 4.0)
+    write_agent(tmp_path, "oracle-warden", 900.0)
+
+    document = generate_leaderboard(tmp_path, kind=None)
+
+    assert "Mixed-kind view" in document
+    assert "not comparable" in document
+
+
+@pytest.mark.parametrize("clearance", [1, 2])
+def test_below_orange_cannot_open_agent_data(tmp_path, clearance: int) -> None:
+    """The gate is on the viewer, not the data - and it refuses at generation."""
+    with pytest.raises(ClearanceRequired, match="ORANGE"):
+        generate_leaderboard(tmp_path, kind=KIND_AGENT, viewer_clearance=clearance)
+    with pytest.raises(ClearanceRequired):
+        generate_leaderboard(tmp_path, kind=None, viewer_clearance=clearance)
+
+
+@pytest.mark.parametrize("clearance", [3, 4, 5, 6])
+def test_orange_and_up_may_open_it(tmp_path, clearance: int) -> None:
+    write_agent(tmp_path, "oracle-warden", 900.0)
+    assert "oracle-warden" in generate_leaderboard(
+        tmp_path, kind=KIND_AGENT, viewer_clearance=clearance
+    )
+
+
+@pytest.mark.parametrize("clearance", [1, 2, 3, 6])
+def test_every_band_may_open_their_own_board(tmp_path, clearance: int) -> None:
+    write_record(tmp_path, "student", 4.0)
+    assert "@student" in generate_leaderboard(tmp_path, viewer_clearance=clearance)
+
+
+def test_a_record_without_a_kind_partitions_as_human(tmp_path) -> None:
+    """A missing discriminator must not make a citizen vanish from their own board."""
+    path = citizen_path("legacy", tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"citizen": "legacy", "last_velocity": 3.0}), encoding="utf-8")
+
+    assert "@legacy" in generate_leaderboard(tmp_path)
 
 
 def test_unreadable_ledger_is_skipped_not_fatal(tmp_path) -> None:


### PR DESCRIPTION
## Changes Summary

`design_docs/LEADERBOARD.md` writes down the partition rule, and `leaderboard.py` implements it — because a rule recorded while the code violates it is the exact drift Clive audits for.

**The rule:** leaderboards partition by `kind`. A human citizen sees human citizens. The agent board is a separate document. There is no default combined view.

**The gate:** seeing agent data at all requires **ORANGE (3)**. Below it, a citizen is not shown the agent board and is not shown that it exists.

## Why: walking is not driving

Choose walking in a maps application and the estimate is an hour. Choose driving and it is twelve minutes. Nobody looks at that and concludes they are a bad walker, because the mode is the first thing you pick and everything after it is scoped to that choice. The application never presents one ranked list of arrival times with pedestrians at the bottom.

Same unit. Same destination. Meaningless comparison.

An agent shipping eight hundred lines an hour and a student writing their first test are in different modes — and both produce a velocity number *from the same engine*, which is what makes this easy to build and hard to see.

## Two independent reasons

So the rule survives even if someone later decides the first one is overcautious.

**Pedagogical.** A first-week citizen has no reference frame — which is the entire reason this system measures the derivative instead of the position. They cannot tell whether 30% coverage is good; they can tell whether it went up. Absolute position is the one signal they are unable to calibrate, so we do not ask them to. Ranking them below an agent hands them exactly that comparison, with a number attached, from the system built to prevent it. It is `PRD.md` §7's prohibition on ranking by absolute skill arriving through a side door — and it fails quietly, because nobody files a bug saying "the leaderboard made me feel like I should not be here."

**Measurement.** The numbers are not commensurable. Agent velocity is throughput, revision count, and how often output survives review. Citizen velocity is coverage delta, test growth, documentation, iteration. Running both through `calculate_velocity` yields two floats that share a name and measure different things. Combining them is a unit error dressed up as a ranking.

## The gate is on the viewer, not the data

Nothing about an agent record is secret — it sits in the repository like every other citizen's. What is gated is putting an uncalibrated comparison in front of someone with no way to read it.

The partition stops a beginner being *ranked* against an agent. The gate stops them being *handed* the comparison. By ORANGE a citizen has enough context to read agent numbers as a different mode rather than as a verdict, which is also roughly the band where working alongside an agent becomes a professional skill worth making legible.

Refusal happens at **generation**, raising `ClearanceRequired`, rather than rendering the board and hiding it in a template — which would leave the data one view-source away.

## Related Issues

- Relates to #18, and to the `kind` discriminator decided in #20

## Component(s) Affected

- [ ] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [x] Persona/Voice System
- [x] State Management
- [x] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 150 passed, 3 skipped, ruff clean. Fourteen new tests, including:

- An agent with velocity 900 and a student with velocity 4 in the same repository — the student is **rank 1 of humans**, not rank 2 of everything.
- Every band (1, 2, 3, 6) may open their own board; only 3+ may open the agent or mixed one.
- A record with **no `kind` at all** partitions as human — a missing discriminator must not make a citizen vanish from their own board.
- The mixed view states in the document that the two are not comparable.

**Partition happens before sorting.** A sorted mixed list that is filtered afterwards produces the right names against the wrong denominator — the ranks are computed from a population that includes machines. There is a test for the ordering of those two operations, not just the output.

## Documentation Updated

- [ ] Code comments added/updated
- [x] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

**Files Updated:** `design_docs/LEADERBOARD.md` (new)

## Educational Impact Assessment

### Student-Facing Changes

None ship today — `METRICS.md` is not yet generated by the workflow. What changes is what will be *possible* when it is: an INFRARED student cannot be shown an agent's throughput, by construction rather than by remembering to filter.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

This is velocity-over-position defended at the presentation layer. The engine can measure honestly and still be undone by a table that puts a beginner under a bot.

### Clearance Levels Affected

- [x] INFRARED — cannot open agent data
- [x] RED — cannot open agent data
- [x] ORANGE — may
- [x] YELLOW / GREEN / BLUE+ — may
- [ ] Not student-facing

## Additional Notes

**This is not hiding the agents.** They are citizens in the registry, carry `kind: "agent"`, and get their own visible board. A course where students collaborate with coding agents and the agents are invisible in the record would be dishonest about how the work actually happened. Visible, separate, comparable within kind — the comparison a student should be able to make about an agent is *what did it do*, not *did it beat me*.

**Left open deliberately:** whether agent velocity should use this engine at all, and what an agent's metric set contains. Both are downstream of someone actually wanting agent metrics for something, and neither needs deciding to make this rule correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)