### PR TITLE
Wire clearance calibration, and stop the prompt contradicting the validator

### DIFF
--- a/.shodann/citizens/norrisaftcc.json
+++ b/.shodann/citizens/norrisaftcc.json
@@ -7,10 +7,10 @@
   },
   "clearance_level": 2,
   "first_submission": "2026-07-25T23:08:59Z",
-  "last_updated": "2026-07-25T23:58:13Z",
+  "last_updated": "2026-07-26T00:21:20Z",
   "baseline_established": true,
-  "pr_count": 5,
-  "iteration_streak": 5,
+  "pr_count": 6,
+  "iteration_streak": 6,
   "rage_state_encounters": 0,
   "last_metrics": {
     "coverage": 0.0,
@@ -22,9 +22,13 @@
     "lint_issues": 0,
     "syntax_errors": 0
   },
-  "last_velocity": 59.08,
-  "velocity_trend": "ascending",
+  "last_velocity": 4.64,
+  "velocity_trend": "descending",
   "velocity_history": [
+    {
+      "score": 4.64,
+      "date": "2026-07-26T00:21:20Z"
+    },
     {
       "score": 59.08,
       "date": "2026-07-25T23:58:13Z"

--- a/.shodann/citizens/norrisaftcc.json
+++ b/.shodann/citizens/norrisaftcc.json
@@ -7,24 +7,28 @@
   },
   "clearance_level": 2,
   "first_submission": "2026-07-25T23:08:59Z",
-  "last_updated": "2026-07-25T23:38:11Z",
+  "last_updated": "2026-07-25T23:58:13Z",
   "baseline_established": true,
-  "pr_count": 4,
-  "iteration_streak": 4,
+  "pr_count": 5,
+  "iteration_streak": 5,
   "rage_state_encounters": 0,
   "last_metrics": {
     "coverage": 0.0,
-    "test_count": 121,
-    "complexity": 218,
-    "loc": 3668,
-    "functions": 218,
-    "docstrings": 136,
+    "test_count": 142,
+    "complexity": 246,
+    "loc": 4141,
+    "functions": 246,
+    "docstrings": 158,
     "lint_issues": 0,
     "syntax_errors": 0
   },
-  "last_velocity": 9.04,
-  "velocity_trend": "descending",
+  "last_velocity": 59.08,
+  "velocity_trend": "ascending",
   "velocity_history": [
+    {
+      "score": 59.08,
+      "date": "2026-07-25T23:58:13Z"
+    },
     {
       "score": 9.04,
       "date": "2026-07-25T23:38:11Z"

--- a/prompts/01_base_shodann_prompt.md
+++ b/prompts/01_base_shodann_prompt.md
@@ -188,8 +188,8 @@ Current Clearance: {{ CLEARANCE_NAME }}
 
 ## Concept Limits
 
-- Address at MOST 2 growth opportunities
-- Provide exactly 1 recommended next iteration
+- Address at MOST {{ MAX_OPPORTUNITIES }} growth opportunities
+- {{ ITERATION_LIMIT }}
 - Keep explanations brief - one concept, one example, move on
 - Match complexity of suggestions to clearance level
 
@@ -226,10 +226,9 @@ returning citizen, reference improvement from previous submissions.]
 problems. Match complexity to clearance level. Include brief code example
 only if helpful and appropriate to clearance.]
 
-### [WRENCH EMOJI] Recommended Iteration
+### {{ ITERATION_MARK }} {{ ITERATION_HEADING }}
 
-[ONE specific, actionable thing they can do in their next commit. Make it
-achievable within 30 minutes of work. Frame as "level up" not "fix this".]
+{{ ITERATION_GUIDANCE }}
 
 {{ RAGE_SECTION_IF_ACTIVE }}
 
@@ -240,7 +239,7 @@ achievable within 30 minutes of work. Frame as "level up" not "fix this".]
 
 ## Word Limit
 
-**CRITICAL**: Keep total response under 400 words. Every word must earn its
+**CRITICAL**: Keep total response under {{ WORD_CAP }} words. Every word must earn its
 place. Be specific, not generic. Every piece of feedback must reference
 something concrete from this citizen's submission.
 
@@ -251,7 +250,7 @@ Use these emojis for section headers ONLY:
 - [ROCKET EMOJI] = Velocity report
 - [CHECK EMOJI] = Approved patterns
 - [CHART EMOJI] = Growth opportunities
-- [WRENCH EMOJI] = Recommended iteration
+- [WRENCH EMOJI] = Recommended iteration (or [MAGNIFYING GLASS EMOJI] for Observations at BLUE+)
 - [LOCK EMOJI] = Security observations (RAGE STATE only)
 
 Do NOT use emojis within paragraph text except for:

--- a/src/shodann/clearance.py
+++ b/src/shodann/clearance.py
@@ -1,0 +1,83 @@
+"""What SHODANN says differently to each band, and why.
+
+The ladder changes posture twice, not once (design_docs/CLEARANCE_REGISTER.md):
+it *teaches* from INFRARED to YELLOW, *mentors* at GREEN, and *reports* at
+BLUE+. Until now that was decided in two design documents and enforced by the
+validator, while the prompt said nothing about it at all - LAYER 3's clearance
+slot rendered as an empty string for every citizen.
+
+Worse, the two halves disagreed. The validator swapped `Recommended Iteration`
+for `Observations` at BLUE+ while the template kept instructing the old
+heading, so a BLUE+ citizen's review was rejected, retried, rejected and
+dropped to the fallback every single time.
+
+The fix is not to correct the template. It is to derive the format rules the
+prompt states from the same :class:`~shodann.validator.ResponseSpec` the
+validator checks, so the two cannot drift apart again.
+"""
+
+from __future__ import annotations
+
+from .state import clearance_name
+from .validator import ResponseSpec
+
+__all__ = ["ITERATION_GUIDANCE", "clearance_instructions", "iteration_guidance"]
+
+TEACHES = """\
+This citizen is building a reference frame and cannot yet calibrate absolute
+position, so speak only about movement. Explain one concept at a time with a
+concrete example drawn from their own submission. Define any term you
+introduce. Do not compare them to anyone."""
+
+MENTORS = """\
+This citizen leads work that others depend on. Name the *consequence* rather
+than the fix - "this module's complexity is now carried by one person" rather
+than "split this function". The recommended step may be delegation,
+documentation or a review practice rather than code."""
+
+REPORTS = """\
+This citizen may have written the standard you are applying, so do not teach
+them their own rules. Report findings and stop. State uncertainty plainly when
+two metrics disagree - "these two readings conflict and I cannot tell which is
+right" is the most useful sentence available at this band. Drop the
+encouragement scaffolding; the vocabulary rules still apply, because they are
+the persona rather than a beginner accommodation."""
+
+BANDS = {
+    1: (TEACHES, "Keep the next step under 15 minutes."),
+    2: (TEACHES, "Keep the next step under 30 minutes."),
+    3: (TEACHES, "Keep the next step under 30 minutes."),
+    4: (TEACHES, "The next step may take up to an hour."),
+    5: (MENTORS, "The next step may take up to an hour."),
+    6: (REPORTS, ""),
+}
+
+ITERATION_GUIDANCE = {
+    "Recommended Iteration": (
+        "[ONE specific, actionable thing they can do in their next commit. "
+        "{timebox} Frame as \"level up\" not \"fix this\".]"
+    ),
+    "Observations": (
+        "[What you noticed and could not resolve from the data. Phrase as open "
+        "questions to a peer, not as assignments. Omit this section entirely "
+        "rather than manufacturing an observation.]"
+    ),
+}
+
+
+def clearance_instructions(level: int) -> str:
+    """The pedagogical guidance injected into LAYER 3 for one band."""
+    posture, timebox = BANDS.get(max(1, min(level, 6)), BANDS[2])
+    name = clearance_name(level)
+    lines = [f"Current band: **{name}**.", "", posture]
+    if timebox:
+        lines += ["", timebox]
+    return "\n".join(lines)
+
+
+def iteration_guidance(spec: ResponseSpec, level: int) -> str:
+    """Bracketed guidance for whichever fourth section this band actually gets."""
+    heading = spec.headings[-1] if spec.headings else "Recommended Iteration"
+    _, timebox = BANDS.get(max(1, min(level, 6)), BANDS[2])
+    template = ITERATION_GUIDANCE.get(heading, ITERATION_GUIDANCE["Recommended Iteration"])
+    return template.format(timebox=timebox or "").replace("  ", " ").strip()

--- a/src/shodann/prompts.py
+++ b/src/shodann/prompts.py
@@ -34,7 +34,9 @@ from pathlib import Path
 
 from jinja2 import Environment, StrictUndefined
 
+from .clearance import clearance_instructions, iteration_guidance
 from .state import CitizenRecord, clearance_name
+from .validator import STANDARD, ResponseSpec, for_clearance
 from .velocity import CodeMetrics, VelocityResult
 
 __all__ = [
@@ -206,7 +208,7 @@ def build_context(
     tests_passed: int = 0,
     tests_failed: int = 0,
     style_issue_count: int = 0,
-    clearance_instructions: str = "",
+    spec: ResponseSpec | None = None,
     security_section: str = "",
     rage_section: str = "",
     mode_statement: str = "NORMAL (Growth Celebration)",
@@ -227,6 +229,19 @@ def build_context(
     """
     previous = record.last_metrics or CodeMetrics.baseline()
     current = result.deltas
+
+    # The format rules the prompt states are derived from the spec the
+    # validator enforces. Anything else is two sources of truth pretending to
+    # be one: the template used to instruct "Recommended Iteration" while the
+    # validator demanded "Observations" at BLUE+, so every review at that band
+    # was rejected, retried, rejected and dropped to the fallback.
+    spec = spec or for_clearance(STANDARD, record.clearance_level)
+    iteration_heading = spec.headings[-1] if spec.headings else "Recommended Iteration"
+    iteration_limit = (
+        "Provide exactly 1 recommended next iteration"
+        if iteration_heading == "Recommended Iteration"
+        else f"Provide at most 1 item under {iteration_heading}, or omit the section"
+    )
 
     # When coverage is absent the rows are dropped entirely rather than filled
     # with a phrase. Filling them was tried: an 8B model dutifully narrated
@@ -269,8 +284,20 @@ def build_context(
         "VELOCITY_SCORE": result.score,
         "VELOCITY_ASSESSMENT": result.assessment,
         "SECURITY_SECTION": security_section,
-        "CLEARANCE_INSTRUCTIONS": clearance_instructions,
+        "CLEARANCE_INSTRUCTIONS": clearance_instructions(record.clearance_level),
         "RAGE_SECTION_IF_ACTIVE": rage_section,
+        "ITERATION_HEADING": iteration_heading,
+        # design_docs/CLEARANCE_REGISTER.md specifies a magnifier for the
+        # peer-register section; a wrench is for someone being handed a task.
+        "ITERATION_MARK": (
+            "[MAGNIFYING GLASS EMOJI]"
+            if iteration_heading == "Observations"
+            else "[WRENCH EMOJI]"
+        ),
+        "ITERATION_GUIDANCE": iteration_guidance(spec, record.clearance_level),
+        "ITERATION_LIMIT": iteration_limit,
+        "WORD_CAP": spec.max_words,
+        "MAX_OPPORTUNITIES": spec.max_opportunities,
     }
 
 

--- a/src/shodann/review.py
+++ b/src/shodann/review.py
@@ -224,6 +224,9 @@ def review(
             files_changed=facts["files_changed"],
             lines_added=facts["lines_added"],
             lines_removed=facts["lines_removed"],
+            # The same spec the response will be judged against, so the
+            # instructions and the checks cannot disagree.
+            spec=spec,
             # Rung 1 runs no coverage tool, so the reading is absent rather
             # than zero. Saying so is the difference between a model reporting
             # a gap and a model celebrating one.

--- a/tests/test_clearance.py
+++ b/tests/test_clearance.py
@@ -1,0 +1,110 @@
+"""The prompt and the validator must not be able to disagree.
+
+Before this, the template instructed "Recommended Iteration" while the
+validator demanded "Observations" at BLUE+, so every review at that band was
+rejected, retried, rejected, and dropped to the facts-only fallback. The
+format rules the prompt states are now derived from the spec the validator
+enforces, and these tests assert that for every band and every mode.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from shodann.clearance import clearance_instructions
+from shodann.prompts import build_context, render_prompt
+from shodann.state import CitizenRecord
+from shodann.validator import SPECS, STANDARD, for_clearance
+from shodann.velocity import CodeMetrics, calculate_velocity
+
+BANDS = [1, 2, 3, 4, 5, 6]
+HEADING = re.compile(r"^### .*?([A-Z][A-Za-z +-]+)$", re.MULTILINE)
+
+
+def rendered_for(level: int, spec=None) -> str:
+    record = CitizenRecord(citizen="octocat", clearance_level=level, pr_count=3)
+    result = calculate_velocity(CodeMetrics(test_count=8), None, 2)
+    return render_prompt(
+        build_context(
+            result,
+            record,
+            pr_title="Add inventory tests",
+            files_changed=2,
+            lines_added=40,
+            lines_removed=3,
+            spec=spec,
+            coverage_instrumented=False,
+        )
+    )
+
+
+@pytest.mark.parametrize("level", BANDS)
+def test_the_prompt_asks_for_the_heading_the_validator_requires(level: int) -> None:
+    spec = for_clearance(STANDARD, level)
+    rendered = rendered_for(level, spec)
+
+    mark = "\U0001f50d" if spec.headings[-1] == "Observations" else "\U0001f527"
+    assert f"### {mark} {spec.headings[-1]}" in rendered
+
+
+@pytest.mark.parametrize("level", BANDS)
+def test_the_prompt_states_the_word_cap_the_validator_enforces(level: int) -> None:
+    spec = for_clearance(STANDARD, level)
+    assert f"under {spec.max_words} words" in rendered_for(level, spec)
+
+
+@pytest.mark.parametrize("level", BANDS)
+def test_the_prompt_states_the_opportunity_cap_the_validator_enforces(level: int) -> None:
+    spec = for_clearance(STANDARD, level)
+    assert f"at MOST {spec.max_opportunities} growth" in rendered_for(level, spec)
+
+
+@pytest.mark.parametrize("mode", sorted(SPECS))
+def test_every_mode_agrees_with_its_own_spec(mode: str) -> None:
+    """Not just the clearance bands - the edge-case handlers too."""
+    spec = SPECS[mode]
+    rendered = rendered_for(2, spec)
+
+    mark = "\U0001f50d" if spec.headings[-1] == "Observations" else "\U0001f527"
+    assert f"### {mark} {spec.headings[-1]}" in rendered
+    assert f"under {spec.max_words} words" in rendered
+
+
+# --- the clearance layer is no longer empty -------------------------------
+
+
+@pytest.mark.parametrize("level", BANDS)
+def test_layer_three_carries_guidance_for_every_band(level: int) -> None:
+    guidance = clearance_instructions(level)
+
+    assert guidance.strip(), "the clearance slot rendered as an empty string for months"
+    assert guidance in rendered_for(level)
+
+
+def test_the_bands_change_posture_twice() -> None:
+    """Teaches, then mentors at GREEN, then reports at BLUE+."""
+    assert "one concept at a time" in clearance_instructions(2)
+    assert "consequence" in clearance_instructions(5)
+    assert "do not teach" in clearance_instructions(6).lower()
+
+
+def test_beginners_get_a_shorter_timebox_than_seniors() -> None:
+    assert "under 15 minutes" in clearance_instructions(1)
+    assert "under 30 minutes" in clearance_instructions(2)
+    assert "up to an hour" in clearance_instructions(5)
+
+
+def test_blue_plus_is_not_assigned_homework() -> None:
+    rendered = rendered_for(6, for_clearance(STANDARD, 6))
+
+    assert "Observations" in rendered
+    assert "Recommended Iteration" not in rendered
+    assert "open questions to a peer" in rendered
+    assert "under 250 words" in rendered
+
+
+def test_an_out_of_range_band_still_renders() -> None:
+    assert clearance_instructions(99).strip()
+    assert clearance_instructions(0).strip()


### PR DESCRIPTION
## Changes Summary

The clearance ladder was decided in `PRD.md` §8, described across two design documents, and enforced by the validator — while **the prompt said nothing about it**. `{{ CLEARANCE_INSTRUCTIONS }}` rendered as an empty string for every citizen, so the "4-layer prompt" was really 3½.

Worse, the two halves disagreed, and the disagreement was fatal rather than cosmetic:

| At BLUE+ | Prompt instructed | Validator required |
|---|---|---|
| Fourth section | `Recommended Iteration` | **`Observations`** |
| Word cap | 400 | **250** |
| Opportunities | 2 | **1** |

A model obeys the prompt. The validator rejects it. The retry names the missing section, the model produces the same shape again, and the review **drops to the facts-only fallback — every time**, for the one band the maintainer occupies under the register's own role rule.

## The fix is structural, not a correction

Fixing the template would have left two sources of truth that happened to agree this afternoon.

Instead, the format rules the prompt *states* are derived from the `ResponseSpec` the validator *checks*: the fourth heading, its mark, its guidance text, the word cap, and the opportunity limit. `review.py` passes the same spec object into both. They cannot drift apart again, because there is only one of them.

## `clearance.py`

Carries the posture the register describes — **teaches** through YELLOW, **mentors** at GREEN, **reports** at BLUE+ — plus each band's timebox (15 minutes at INFRARED, 30 through ORANGE, an hour at YELLOW and GREEN, none at BLUE+).

BLUE+ now gets open questions instead of homework, under a magnifier rather than a wrench. A wrench is for someone being handed a task.

## Related Issues

- Relates to #18, #24
- Implements `design_docs/CLEARANCE_REGISTER.md`

## Component(s) Affected

- [ ] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [x] Persona/Voice System
- [ ] State Management
- [x] Templates
- [ ] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 202 passed, 3 skipped, ruff clean.

The new tests assert the **agreement** rather than the implementation, which is the property that actually matters: parametrised across all six bands *and* all seven modes, the heading the prompt asks for is the heading the validator requires, and the cap it states is the cap that will be enforced. A future edit to either side breaks a test naming the other.

Also asserted: the clearance slot is non-empty for every band (it was empty for all of them), the posture changes twice rather than once, and an out-of-range band still renders rather than raising.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

`clearance.py`'s module docstring records the failure that motivated it, since "derive the prompt from the spec" looks like over-engineering until you know what the alternative did.

## Educational Impact Assessment

### Student-Facing Changes

Two, both real:

1. **Feedback is now calibrated to the band at all.** Before this, an INFRARED beginner and a GREEN lead received identically-pitched reviews, because the layer that was supposed to differentiate them was blank. A beginner now gets one concept at a time with every term defined and a next step under fifteen minutes; a lead gets consequence-framing and may be pointed at delegation or documentation rather than code.
2. **BLUE+ citizens get a working review at all**, instead of a facts-only fallback caused by an argument between two halves of our own system.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

"Appropriate for target clearance level" is the box this PR exists to make true rather than aspirational.

The vocabulary rules apply unchanged at every band, including BLUE+ — they are the persona, not a beginner accommodation, and the clearance guidance says so explicitly so a model does not infer that peer-register means dropping the voice.

### Clearance Levels Affected

- [x] INFRARED — 1 opportunity, 15-minute step, every term defined
- [x] RED — teaches, 30-minute step
- [x] ORANGE — teaches, 30-minute step
- [x] YELLOW — teaches, hour-long step
- [x] GREEN — mentors, names consequence over fix
- [x] BLUE+ — reports, 250 words, Observations, no homework

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**`prompts/03_clearance_variations.md` is now superseded in practice** and still contradicts `CLEARANCE_REGISTER.md` on BLUE+ (2 opportunities versus 0–1, and it retains `Recommended Iteration`). Clive flagged both in his first audit. The code follows the register, which is the higher authority per `CLAUDE.md`'s precedence rule; `03` should be reconciled or retired when the remaining templates get markers, and this PR deliberately does not touch it.

**Not in scope:** the edge-case handlers still have no `TEMPLATE:BEGIN` markers, so `SPECS["empty_pr"]` and friends are validated but never rendered. The agreement tests cover them anyway, so the day they are wired the format rules will already match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)