### PR TITLE
Give degradation its own mode, and let a backend refuse what it cannot serve

### DIFF
--- a/.shodann/citizens/norrisaftcc.json
+++ b/.shodann/citizens/norrisaftcc.json
@@ -7,24 +7,28 @@
   },
   "clearance_level": 2,
   "first_submission": "2026-07-25T23:08:59Z",
-  "last_updated": "2026-07-25T23:38:11Z",
+  "last_updated": "2026-07-26T00:10:34Z",
   "baseline_established": true,
-  "pr_count": 4,
-  "iteration_streak": 4,
+  "pr_count": 5,
+  "iteration_streak": 5,
   "rage_state_encounters": 0,
   "last_metrics": {
     "coverage": 0.0,
-    "test_count": 121,
-    "complexity": 218,
-    "loc": 3668,
-    "functions": 218,
-    "docstrings": 136,
+    "test_count": 147,
+    "complexity": 254,
+    "loc": 4350,
+    "functions": 254,
+    "docstrings": 168,
     "lint_issues": 0,
     "syntax_errors": 0
   },
-  "last_velocity": 9.04,
-  "velocity_trend": "descending",
+  "last_velocity": 78.4,
+  "velocity_trend": "ascending",
   "velocity_history": [
+    {
+      "score": 78.4,
+      "date": "2026-07-26T00:10:34Z"
+    },
     {
       "score": 9.04,
       "date": "2026-07-25T23:38:11Z"
@@ -41,5 +45,6 @@
       "score": 328.3,
       "date": "2026-07-25T23:08:59Z"
     }
-  ]
+  ],
+  "last_degradation": "no model configured"
 }

--- a/.shodann/citizens/norrisaftcc.json
+++ b/.shodann/citizens/norrisaftcc.json
@@ -7,10 +7,10 @@
   },
   "clearance_level": 2,
   "first_submission": "2026-07-25T23:08:59Z",
-  "last_updated": "2026-07-26T00:10:34Z",
+  "last_updated": "2026-07-26T00:21:21Z",
   "baseline_established": true,
-  "pr_count": 5,
-  "iteration_streak": 5,
+  "pr_count": 6,
+  "iteration_streak": 6,
   "rage_state_encounters": 0,
   "last_metrics": {
     "coverage": 0.0,
@@ -22,9 +22,13 @@
     "lint_issues": 0,
     "syntax_errors": 0
   },
-  "last_velocity": 78.4,
-  "velocity_trend": "ascending",
+  "last_velocity": 6.46,
+  "velocity_trend": "descending",
   "velocity_history": [
+    {
+      "score": 6.46,
+      "date": "2026-07-26T00:21:21Z"
+    },
     {
       "score": 78.4,
       "date": "2026-07-26T00:10:34Z"

--- a/src/shodann/capability.py
+++ b/src/shodann/capability.py
@@ -1,0 +1,89 @@
+"""What a configured model is allowed to be asked for.
+
+A backend declares the bands and modes it serves, and SHODANN checks before
+generating rather than discovering afterwards. Asking a 3B model for the BLUE+
+peer register produced two failed attempts and a fallback; asking it to decline
+produces the same outcome in one step, with a reason worth recording.
+
+The scope subset is not a degraded product, it is a correctly configured one.
+A local model serving INFRARED through ORANGE on Python submissions covers the
+bands where the work is *pattern completion over a fixed vocabulary* - one
+concept, defined terms, a short timebox, a small budget. That is what small
+models are good at, and the 3B trials bear it out: its failures were always
+content, never form.
+
+The higher bands ask for something else. GREEN wants consequence-framing;
+BLUE+ wants the model to stop teaching and to omit a section when it has
+nothing genuine to say. Suppressing a trained behaviour and judging sufficiency
+are the two hardest things to get from a small model, and they only appear at
+the top of the ladder.
+
+Deliberate refusal beats silent degradation, which is the same rule
+`ClearanceRequired` follows on the leaderboard.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = [
+    "FULL",
+    "LOCAL_SMALL",
+    "Capabilities",
+    "refusal_reason",
+]
+
+
+@dataclass(frozen=True)
+class Capabilities:
+    """The envelope a backend declares. Anything outside it is refused, not attempted."""
+
+    name: str
+    max_band: int = 6
+    modes: frozenset[str] = field(
+        default_factory=lambda: frozenset(
+            {
+                "standard",
+                "first_submission",
+                "empty_pr",
+                "all_failing",
+                "massive_pr",
+                "syntax_barrier",
+                "config_only",
+            }
+        )
+    )
+
+    def serves(self, *, band: int, mode: str) -> bool:
+        return band <= self.max_band and mode in self.modes
+
+
+FULL = Capabilities(name="full")
+"""A hosted model of ordinary size. Serves every band and every mode."""
+
+LOCAL_SMALL = Capabilities(
+    name="local-small",
+    max_band=3,
+    modes=frozenset({"standard", "first_submission", "empty_pr", "syntax_barrier"}),
+)
+"""INFRARED through ORANGE, simple workflows, Python.
+
+Deliberately excludes GREEN and BLUE+, and the edge-case handlers that ask for
+judgement about scale or wholesale failure.
+"""
+
+
+def refusal_reason(capabilities: Capabilities, *, band: int, mode: str) -> str | None:
+    """Why this request is outside the envelope, or ``None`` if it is inside.
+
+    The string reaches a citizen, so it says what happened without apology and
+    without blaming them.
+    """
+    if capabilities.serves(band=band, mode=mode):
+        return None
+    if band > capabilities.max_band:
+        return (
+            f"this allocation serves clearance {capabilities.max_band} and below; "
+            f"this submission is clearance {band}"
+        )
+    return f"this allocation does not serve {mode.replace('_', ' ')} submissions"

--- a/src/shodann/review.py
+++ b/src/shodann/review.py
@@ -24,6 +24,7 @@ import json
 import sys
 from pathlib import Path
 
+from .capability import FULL, Capabilities, refusal_reason
 from .groundedness import check_groundedness
 from .llm import LLMConfig, LLMUnavailable, generate
 from .prompts import build_context, render_prompt
@@ -38,7 +39,7 @@ from .validator import (
 )
 from .velocity import CodeMetrics, VelocityResult, calculate_velocity
 
-__all__ = ["collect_metrics", "facts_only_comment", "main", "pr_facts", "review"]
+__all__ = ["collect_metrics", "main", "pr_facts", "reduced_allocation_comment", "review"]
 
 EXCLUDED_DIRS = frozenset(
     {
@@ -105,35 +106,45 @@ def collect_metrics(root: Path | str = ".") -> CodeMetrics:
     )
 
 
-def facts_only_comment(
+def reduced_allocation_comment(
     facts: dict, result: VelocityResult, record: CitizenRecord, reason: str
 ) -> str:
-    """The comment a citizen gets when no model could be reached.
+    """The review a citizen gets when nothing interpreted their readings.
 
     PRD section 8 commits to graceful degradation: a student always receives
-    *some* feedback. This is that floor, and it honours the same output
-    contract as a generated response - it is quieter, not lesser.
+    *some* feedback. This is that floor, and it is a *visibly different*
+    review rather than a quieter one wearing a footnote.
+
+    The readings here are as trustworthy as any other review's - they come
+    from tools, which cannot invent. What is missing is interpretation, and
+    the mode says so where a citizen will read it. If the lesson is "say when
+    you don't know", the saying has to be as visible as the knowing.
     """
     celebrations = "\n".join(f"- {line}" for line in result.celebrations[:3])
     opportunities = "\n".join(f"- {line}" for line in result.opportunities) or (
         "- The Algorithm has no growth opportunities to raise this iteration."
     )
-    next_step = (
-        "Keep the iteration cadence. The Algorithm will have more to say once "
-        "the analysis tools are online."
-    )
 
     return f"""## \U0001f916 SHODANN Analysis Complete
 
-**Citizen**: @{facts["citizen"]} | **Clearance**: {clearance_name(record.clearance_level)} | \
-**Velocity**: {result.score}
+**Citizen**: @{facts["citizen"]} | \
+**Clearance**: {clearance_name(record.clearance_level)} | \
+**Status**: REDUCED ALLOCATION
 
 ---
 
-### \U0001f680 Shipping Velocity Report
+### ⚡ Resource Advisory
+
+The Algorithm reviewed this submission using minimal resources. You are welcome.
+
+Synthesis was unavailable this cycle ({reason}), so what follows is instrument
+readings only - measured, not interpreted. The numbers are sound. The judgement
+is yours. Please verify anything that matters.
+
+### \U0001f4ca Instrument Readings
 
 {result.assessment}. Submission {record.pr_count} across {result.iterations} \
-commit(s), touching {facts["files_changed"]} file(s).
+commit(s), touching {facts["files_changed"]} file(s). Velocity: {result.score}.
 
 ### ✅ Algorithm-Approved Patterns
 
@@ -143,16 +154,14 @@ commit(s), touching {facts["files_changed"]} file(s).
 
 {opportunities}
 
-### \U0001f527 Recommended Iteration
-
-{next_step}
-
 ---
 
-*The Algorithm sees your growth. The Algorithm is pleased.*
-
-<sub>Generated without model synthesis ({reason}).</sub>
+*The Algorithm sees your growth. The Algorithm is operating within budget.*
 """
+
+
+class _AlreadyResolved(Exception):
+    """The review was settled before a model was needed."""
 
 
 def _spec_for(record: CitizenRecord, mode: str) -> ResponseSpec:
@@ -197,6 +206,7 @@ def review(
     *,
     root: Path | str = ".",
     config: LLMConfig | None = None,
+    capabilities: Capabilities = FULL,
     mode: str = "standard",
     opener=None,
     write_state: bool = True,
@@ -209,14 +219,27 @@ def review(
     metrics = collect_metrics(root)
     result = calculate_velocity(metrics, record.last_metrics, facts["commits"])
 
-    if write_state:
-        record = save_citizen_history(facts["citizen"], metrics, result, root)
-    else:
-        record.pr_count += 1
-
+    # The submission number this is about to become. State is written at the
+    # end rather than here, because what gets recorded includes whether the
+    # review degraded - which is not known yet.
+    record.pr_count += 1
     spec = _spec_for(record, mode)
 
+    # Refuse outside the envelope rather than attempting and discovering. A 3B
+    # model asked for the BLUE+ peer register spent two attempts failing; this
+    # reaches the same outcome in one step, with a reason worth recording.
+    degradation: str | None = refusal_reason(
+        capabilities, band=record.clearance_level, mode=mode
+    )
+    body = ""
+    if degradation:
+        # Refused before a prompt is even assembled: no tokens, no latency,
+        # and a reason a citizen can read.
+        body = reduced_allocation_comment(facts, result, record, degradation)
+
     try:
+        if degradation:
+            raise _AlreadyResolved
         context = build_context(
             result,
             record,
@@ -238,9 +261,18 @@ def review(
         # will not once SHODANN reviews someone else's repo, and at that point
         # the templates need to ship as package data.
         prompt = render_prompt(context)
-        return _synthesise(prompt, spec, config, opener=opener)
+        body = _synthesise(prompt, spec, config, opener=opener)
+    except _AlreadyResolved:
+        pass
     except LLMUnavailable as unavailable:
-        return facts_only_comment(facts, result, record, str(unavailable))
+        degradation = str(unavailable)
+        body = reduced_allocation_comment(facts, result, record, degradation)
+
+    if write_state:
+        save_citizen_history(
+            facts["citizen"], metrics, result, root, degradation=degradation
+        )
+    return body
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/shodann/state.py
+++ b/src/shodann/state.py
@@ -95,6 +95,8 @@ class CitizenRecord:
     last_velocity: float = 0.0
     velocity_trend: str = TREND_NEW
     velocity_history: list[dict] = field(default_factory=list)
+    last_degradation: str | None = None
+    """Why the most recent review went out uninterpreted, or None."""
 
     # -- serialisation -----------------------------------------------------
 
@@ -120,6 +122,7 @@ class CitizenRecord:
             last_velocity=data.get("last_velocity", 0.0),
             velocity_trend=data.get("velocity_trend", TREND_NEW),
             velocity_history=list(data.get("velocity_history", [])),
+            last_degradation=data.get("last_degradation"),
         )
 
     def to_dict(self) -> dict:
@@ -138,6 +141,7 @@ class CitizenRecord:
             "last_velocity": self.last_velocity,
             "velocity_trend": self.velocity_trend,
             "velocity_history": list(self.velocity_history),
+            "last_degradation": self.last_degradation,
         }
 
 
@@ -192,6 +196,7 @@ def save_citizen_history(
     *,
     config: VelocityConfig = DEFAULT_CONFIG,
     now: str | None = None,
+    degradation: str | None = None,
 ) -> CitizenRecord:
     """Fold one submission into the citizen's ledger and write it atomically.
 
@@ -206,6 +211,9 @@ def save_citizen_history(
     record.last_velocity = result.score
     record.last_updated = timestamp
     record.baseline_established = True
+    # Recorded whether or not it happened, so a cleared degradation does
+    # not leave last cycle's reason looking current.
+    record.last_degradation = degradation
     if record.first_submission is None:
         record.first_submission = timestamp
 

--- a/src/shodann/validator.py
+++ b/src/shodann/validator.py
@@ -206,6 +206,31 @@ CONFIG_ONLY = ResponseSpec(
     opportunities_heading="Algorithm Observations",
 )
 
+REDUCED_ALLOCATION = ResponseSpec(
+    name="reduced_allocation",
+    max_words=250,
+    headings=(
+        "Resource Advisory",
+        "Instrument Readings",
+        "Algorithm-Approved Patterns",
+        "Growth Opportunities",
+    ),
+    max_opportunities=2,
+    header_field="Status",
+)
+"""The Algorithm reviewed you cheaply and would like credit for it.
+
+Entered when synthesis is unavailable, when the configured model does not
+serve this citizen's band, or when a response failed the contract twice. The
+readings in it are as good as any other review's - they come from tools - but
+nothing has interpreted them, and the mode says so out loud rather than
+burying it in a footnote.
+
+A system that knows its own limits announces them. That is the lesson the mode
+exists to teach, and it only teaches it if the announcement is as visible as
+the findings.
+"""
+
 SPECS = {
     spec.name: spec
     for spec in (
@@ -216,6 +241,7 @@ SPECS = {
         MASSIVE_PR,
         SYNTAX_BARRIER,
         CONFIG_ONLY,
+        REDUCED_ALLOCATION,
     )
 }
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -7,10 +7,11 @@ import json
 
 import pytest
 
+from shodann.capability import LOCAL_SMALL
 from shodann.llm import LLMConfig, LLMUnavailable, generate
 from shodann.review import collect_metrics, main, pr_facts, review
-from shodann.state import citizen_path, load_citizen_history
-from shodann.validator import STANDARD, blocks_posting, validate
+from shodann.state import CitizenRecord, citizen_path, load_citizen_history
+from shodann.validator import REDUCED_ALLOCATION, STANDARD, blocks_posting, validate
 
 EVENT = {
     "pull_request": {
@@ -175,7 +176,7 @@ def test_two_bad_responses_fall_back_rather_than_posting_the_second(tmp_path) ->
     body = review(EVENT, root=tmp_path, config=CONFIG, opener=responder(bad, bad))
 
     assert "You should" not in body
-    assert "Generated without model synthesis" in body
+    assert "REDUCED ALLOCATION" in body
 
 
 # --- degradation ----------------------------------------------------------
@@ -198,12 +199,65 @@ def test_an_unreachable_model_still_produces_a_comment(tmp_path) -> None:
     assert "SHODANN Analysis Complete" in body
 
 
-def test_the_fallback_comment_honours_the_output_contract(tmp_path) -> None:
-    """The degraded path is quieter, not lesser. It passes the same validator."""
+def test_the_degraded_comment_honours_its_own_contract(tmp_path) -> None:
+    """A visibly different review, not a quieter one wearing a footnote."""
     body = review(EVENT, root=tmp_path, config=LLMConfig())
-    violations = validate(body, STANDARD)
 
+    violations = validate(body, REDUCED_ALLOCATION)
     assert not blocks_posting(violations), [str(v) for v in violations]
+    assert blocks_posting(validate(body, STANDARD)), "it is deliberately not a standard review"
+
+
+def test_the_advisory_makes_the_joke_and_the_caveat_the_same_sentence(tmp_path) -> None:
+    body = review(EVENT, root=tmp_path, config=LLMConfig())
+
+    assert "using minimal resources. You are welcome." in body
+    assert "measured, not interpreted" in body
+    assert "verify anything that matters" in body
+    assert "operating within budget" in body
+
+
+def test_a_band_outside_the_allocation_is_refused_not_attempted(tmp_path) -> None:
+    """A 3B asked for BLUE+ spent two attempts failing. This takes one step."""
+    def must_not_be_called(request, timeout=None):
+        raise AssertionError("the model was asked for a band it does not serve")
+
+    event = {"pull_request": {**EVENT["pull_request"], "user": {"login": "peer"}}}
+    citizen_path("peer", tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    citizen_path("peer", tmp_path).write_text(
+        json.dumps(CitizenRecord(citizen="peer", clearance_level=6).to_dict()),
+        encoding="utf-8",
+    )
+
+    body = review(
+        event, root=tmp_path, config=CONFIG, capabilities=LOCAL_SMALL,
+        opener=must_not_be_called, write_state=False,
+    )
+
+    assert "REDUCED ALLOCATION" in body
+    assert "clearance 3 and below" in body
+
+
+def test_a_mode_outside_the_allocation_is_refused(tmp_path) -> None:
+    body = review(
+        EVENT, root=tmp_path, config=CONFIG, capabilities=LOCAL_SMALL,
+        mode="massive_pr", opener=responder("unused"), write_state=False,
+    )
+    assert "does not serve massive pr submissions" in body
+
+
+def test_the_allocation_serves_the_bands_it_claims(tmp_path) -> None:
+    body = review(
+        EVENT, root=tmp_path, config=CONFIG, capabilities=LOCAL_SMALL,
+        opener=responder(GOOD_RESPONSE),
+    )
+    assert body == GOOD_RESPONSE.strip(), "RED is inside a local allocation"
+
+
+def test_the_reason_is_recorded_on_the_citizen(tmp_path) -> None:
+    """So the capability matrix comes from real runs, not hand-maintenance."""
+    review(EVENT, root=tmp_path, config=LLMConfig())
+    assert "no model configured" in load_citizen_history("octocat", tmp_path).last_degradation
 
 
 def test_the_fallback_never_uses_forbidden_vocabulary(tmp_path) -> None:


### PR DESCRIPTION
## Changes Summary

**RAGE STATE means *more* rigorous, not less.** Borrowing it for uncertain output would corrupt the one mode that most needs to be trusted — a citizen who learns *RAGE means the bot is being weird* discounts a real hardcoded-secret finding the day it matters. Degradation gets its own mode.

### REDUCED ALLOCATION

Entered when synthesis is unavailable, when the configured model does not serve this citizen's band, or when a response failed the contract twice.

> **Citizen**: @norrisaftcc | **Clearance**: RED | **Status**: REDUCED ALLOCATION
>
> ### ⚡ Resource Advisory
>
> The Algorithm reviewed this submission using minimal resources. You are welcome.
>
> Synthesis was unavailable this cycle (no model configured), so what follows is instrument readings only — measured, not interpreted. The numbers are sound. The judgement is yours. Please verify anything that matters.

The joke and the caveat are the same sentence. Corporate thrift claimed as a benefit is the satire; *fewer resources burned, output worth checking* is literally true — which is the test a metaphor has to pass: **does it survive having the costume taken off?**

It is a *visibly different* review rather than a quieter one wearing a `<sub>` footnote. If the lesson is "say when you don't know," the saying has to be as visible as the knowing. The readings are as trustworthy as any other review's — they come from tools, which cannot invent. What is missing is interpretation, and the mode says so where a citizen will read it.

### Capability declaration

`capability.py` lets a backend declare the bands and modes it serves.

| | `LOCAL_SMALL` | `FULL` |
|---|---|---|
| Bands | INFRARED–ORANGE | all six |
| Modes | standard, first submission, empty PR, syntax barrier | all seven |

That subset is not a degraded product, it is a correctly configured one. INFRARED–ORANGE is where the work is **pattern completion over a fixed vocabulary** — one concept, defined terms, short timebox, small budget — and the 3B trials bear it out: its failures were always content, never form.

GREEN wants consequence-framing. BLUE+ wants the model to stop teaching and to *omit a section when it has nothing genuine to say*. Suppressing a trained behaviour and judging sufficiency are the two hardest things to get from a small model, and they appear only at the top of the ladder. The band ordering that reflects how much reference frame a *reader* needs turns out to also order how much judgement the *writer* needs.

Asking a 3B for BLUE+ produced two failed attempts and a fallback. Refusing takes one step, costs no tokens, and gives the citizen a reason — the same rule `ClearanceRequired` follows on the leaderboard: **deliberate refusal beats silent degradation**.

## Related Issues

- Relates to #18, #24, #25
- Follows `design_docs/EARLY_RUNS.md` entries 2 and 6

## Component(s) Affected

- [ ] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [x] Persona/Voice System
- [x] State Management
- [ ] Templates
- [ ] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 208 passed, 3 skipped, ruff clean.

The refusal test uses an opener that **raises if the model is called at all**, so "refused, not attempted" is asserted rather than described. Others cover: the degraded comment passing its own spec while deliberately failing `STANDARD`, both halves of the advisory sentence, a band inside the allocation still generating normally, and the reason landing on the citizen record.

**A real bug surfaced while testing the last one:** state was written *before* the review resolved, so a degradation reason could never reach disk. Persistence now happens after the outcome is known — which is also just the right shape, since what gets recorded includes whether the review degraded.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

`capability.py`'s docstring carries the reasoning about why the ladder's top is harder to write, since the envelope looks arbitrary without it.

## Educational Impact Assessment

### Student-Facing Changes

A student can now tell at a glance whether SHODANN was **thinking or just counting**. Before this, a degraded review looked like a normal one with a small footnote; a citizen would reasonably read uninterpreted readings as considered judgement.

What the mode teaches is worth more than the joke: **a system that knows its own limits announces them.** A student watching SHODANN say *"these are instrument readings only, I decline to interpret them"* is watching a machine distinguish *I computed this* from *I couldn't* — precisely the epistemic habit we want from someone learning to work with AI tools. The mode models the behaviour we are asking of them.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

Persona consistency is the box this PR is really defending — by *declining* to reuse RAGE STATE for something it does not mean.

### Clearance Levels Affected

- [x] INFRARED / RED / ORANGE — served by a local allocation
- [x] YELLOW / GREEN / BLUE+ — refused by one, with a reason
- [ ] Not student-facing

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**The capability matrix should be generated, not written.** The refusal reason lands on the citizen record specifically so a backend × band table can be built from real runs. Per the leaderboard rule that already exists, that table is agent data and belongs at ORANGE and above — an INFRARED student seeing "the system reviewing you scores an X here" gets exactly the uncalibrated comparison that gate was built to prevent. The hover-to-read-the-hilarious-failure version belongs with `EARLY_RUNS.md`, where the audience can calibrate it.

**Not done here:** nothing selects `LOCAL_SMALL` yet — the workflow still uses `FULL`. Wiring capability selection to the configured model name is a small follow-on, and deliberately separate from establishing the mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)