### PR TITLE
Write the ledger on merge, not on every review

### DIFF
--- a/.github/workflows/shodann.yml
+++ b/.github/workflows/shodann.yml
@@ -23,10 +23,11 @@ name: SHODANN Educational Oversight Protocol
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # A review runs on every push. It never writes state - see below.
+    types: [opened, synchronize, reopened, closed]
 
 permissions:
-  contents: write        # persist the citizen ledger
+  contents: write        # persist the citizen ledger, on merge only
   pull-requests: write   # post the review comment
 
 concurrency:
@@ -63,6 +64,7 @@ jobs:
         run: pip install --quiet .
 
       - name: Compose the review
+        if: github.event.action != 'closed'
         env:
           # Citizen-controlled text never enters this step as an expression.
           # Python reads the event payload from disk and parses it as JSON.
@@ -70,23 +72,37 @@ jobs:
           SHODANN_LLM_MODEL: ${{ vars.SHODANN_LLM_MODEL }}
           SHODANN_LLM_API_KEY: ${{ secrets.SHODANN_LLM_API_KEY }}
         run: |
+          # --dry-run: a review never writes state. Persistence happens on
+          # merge, in the step below.
           python -m shodann.review \
             --event "$GITHUB_EVENT_PATH" \
             --out shodann-comment.md \
-            --root .
+            --root . \
+            --dry-run
 
       - name: Post the review
+        if: github.event.action != 'closed'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr comment "$PR_NUMBER" --body-file shodann-comment.md
 
+      # A review is not a merge. Recording velocity for work that may never
+      # land makes pr_count measure PR-opening rather than shipping - and,
+      # found the hard way, writing the ledger to every PR branch means two
+      # open pull requests produce two divergent ledgers and the second merge
+      # always conflicts. SHODANN spent an afternoon blocking its own PRs.
       - name: Record the citizen ledger
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true
         env:
           CITIZEN: ${{ github.event.pull_request.user.login }}
         run: |
-          # $CITIZEN is a GitHub username: [A-Za-z0-9-] only, and quoted here
-          # regardless. It is used in a commit message, never in a path.
+          git fetch origin "${GITHUB_BASE_REF}"
+          git checkout "${GITHUB_BASE_REF}"
+          python -m shodann.review \
+            --event "$GITHUB_EVENT_PATH" \
+            --out /tmp/shodann-record.md \
+            --root .
           if [ -z "$(git status --porcelain .shodann)" ]; then
             echo "No ledger change to record."
             exit 0
@@ -95,4 +111,4 @@ jobs:
           git config user.email "shodann[bot]@users.noreply.github.com"
           git add .shodann
           git commit -m "Record velocity for @${CITIZEN}"
-          git push origin "HEAD:${GITHUB_HEAD_REF}"
+          git push origin "HEAD:${GITHUB_BASE_REF}"

--- a/design_docs/EARLY_RUNS.md
+++ b/design_docs/EARLY_RUNS.md
@@ -137,6 +137,24 @@ Three reasons this file exists:
 
 ---
 
+## 7. SHODANN blocked its own pull requests
+
+**Where:** merging four PRs in a row. The first went in; the second and third reported conflicts; the fourth needed three attempts and lost a race twice.
+
+**What conflicted:** exactly one file, every time - `.shodann/citizens/norrisaftcc.json`. SHODANN's own ledger.
+
+**Why:** the review job wrote the ledger to the *pull request branch* on every run. Two open PRs meant two divergent ledgers, and the second merge conflicted by construction. Worse, each push triggered a fresh review, which pushed a fresh ledger commit, which invalidated the merge that was about to happen - a loop that resolves only by winning a race against your own bot.
+
+`PRD.md` section 8 anticipated half of this: *"per-citizen files reduce merge conflicts"*. True across citizens, useless for one citizen with two branches. In a classroom each student has their own repository, so student-versus-student never collides - but any student with two open pull requests hits this on their second merge, and has no idea why.
+
+**The deeper problem the conflict exposed:** a review is not a merge. Recording velocity for work that may never land makes `pr_count` measure pull-request-*opening* rather than shipping, and a citizen who opens and closes five PRs accrues five submissions for nothing.
+
+**What changed:** the review runs on every push and writes no state at all (`--dry-run`). The ledger is written once, on `pull_request: closed` with `merged == true`, against the base branch. Velocity now records what landed.
+
+**What this cost before it was found:** four merges, two conflict resolutions, one lost race, and roughly twenty minutes of a maintainer fighting a bot for control of a JSON file.
+
+---
+
 ## What the pattern says
 
 Every defect on this page needed the system to *run*. None was found by reading code, and the test suite was green through all of them — 136 passing tests while SHODANN told a citizen they had written twice as many tests as they had.


### PR DESCRIPTION
## Changes Summary

Merging four PRs in a row produced three conflicts, and every one was the same file: **SHODANN's own ledger**.

The review job wrote `.shodann/citizens/{user}.json` to the *pull request branch* on every run. Two open PRs meant two divergent ledgers, so the second merge conflicted by construction. Worse, each push triggered a fresh review, which pushed a fresh ledger commit, which invalidated the merge that was about to happen — a loop that resolves only by winning a race against your own bot.

`PRD.md` §8 anticipated half of it: *"per-citizen files reduce merge conflicts."* True **across citizens**, useless for **one citizen with two branches**. Each student has their own repository, so student-versus-student never collides — but any student with two open pull requests hits this on their second merge and has no idea why.

## The conflict exposed a better reason to change it

**A review is not a merge.** Recording velocity for work that may never land makes `pr_count` measure pull-request-*opening* rather than shipping, and a citizen who opens and closes five PRs accrues five submissions for nothing.

| | Before | After |
|---|---|---|
| On every push | review, comment, **write ledger** | review, comment |
| On merge | — | **write ledger**, against the base branch |

Reviews now run with `--dry-run` and write no state at all. The ledger is written once, on `pull_request: closed` with `merged == true`. Velocity records what landed.

## Related Issues

- Relates to #25
- `design_docs/EARLY_RUNS.md` entry 7

## Component(s) Affected

- [x] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [ ] Persona/Voice System
- [x] State Management
- [ ] Templates
- [x] Documentation

## Testing Performed

- [x] Manual testing completed
- [ ] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 208 passed, 3 skipped, ruff clean — unchanged, since no Python changed. The workflow was parsed with PyYAML to confirm the step conditions resolve as intended:

```
triggers: ['opened', 'synchronize', 'reopened', 'closed']
  Compose the review           if=github.event.action != 'closed'
  Post the review              if=github.event.action != 'closed'
  Record the citizen ledger    if=... == 'closed' && ...merged == true
```

**This one cannot be fully tested before merge** — the merge event is the thing under test. The evidence it works is the absence of a ledger commit on this PR's own branch, and the presence of one on `main` after it merges. Worth watching on merge rather than assuming.

## Documentation Updated

- [ ] Code comments added/updated
- [x] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

**Files Updated:** `design_docs/EARLY_RUNS.md` (entry 7), plus the workflow's own comments carrying the reason.

## Educational Impact Assessment

### Student-Facing Changes

Two, and the second is the one that matters:

1. **A student with two open pull requests stops getting mystery conflicts** in a file they did not write, in a directory they did not create, attributed to a bot.
2. **`pr_count` and `velocity_history` now mean "submissions that landed."** Before, a citizen who opened and closed pull requests without merging accrued submissions and velocity history for work that never shipped — which is not a metric anyone would defend if asked directly.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

Reviews still run on every push, so iteration is still observed and still celebrated. Only the *record* moved. Nothing here discourages committing often — it just stops the ledger claiming a merge happened when it did not.

### Clearance Levels Affected

- [x] All levels

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**What it cost to find:** four merges, two conflict resolutions, one lost race against the bot, and about twenty minutes of a maintainer fighting a JSON file for control of their own repository. That is in the field notes, because it is exactly the kind of thing that looks like paranoid design once it is fixed.

**Still open, deliberately:** the `git checkout "$GITHUB_BASE_REF"` in the record step assumes the base branch is checkoutable from the PR-closed event context. That is the standard shape, but it is untested until this merges — if the first post-merge run fails, that line is the suspect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)