### PR TITLE
Fix two defects the merge event exposed

### DIFF
--- a/.github/workflows/shodann.yml
+++ b/.github/workflows/shodann.yml
@@ -52,7 +52,14 @@ jobs:
           # push below sent that merge commit to the citizen's branch on every
           # run. Checking out the real branch tip means the push carries the
           # ledger commit and nothing else.
-          ref: ${{ github.event.pull_request.head.ref }}
+          # On a merge the head branch is usually already deleted, so the
+          # closed-event run checks out the base instead - which is also where
+          # the ledger belongs. Asking for a deleted branch fails the whole
+          # job before any step can decide it did not need it.
+          ref: >-
+            ${{ github.event.action == 'closed'
+                && github.event.pull_request.base.ref
+                || github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       - name: Set up Python
@@ -97,8 +104,7 @@ jobs:
         env:
           CITIZEN: ${{ github.event.pull_request.user.login }}
         run: |
-          git fetch origin "${GITHUB_BASE_REF}"
-          git checkout "${GITHUB_BASE_REF}"
+          # Already on the base branch: the checkout step selected it.
           python -m shodann.review \
             --event "$GITHUB_EVENT_PATH" \
             --out /tmp/shodann-record.md \

--- a/src/shodann/review.py
+++ b/src/shodann/review.py
@@ -281,12 +281,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out", required=True, help="where to write the comment body")
     parser.add_argument("--root", default=".")
     parser.add_argument("--mode", default="standard", choices=sorted(SPECS))
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="compose the review without writing the citizen ledger",
+    )
     args = parser.parse_args(argv)
 
     with Path(args.event).open(encoding="utf-8") as handle:
         event = json.load(handle)
 
-    body = review(event, root=args.root, mode=args.mode)
+    body = review(event, root=args.root, mode=args.mode, write_state=not args.dry_run)
     Path(args.out).write_text(body, encoding="utf-8")
 
     # Never echo the body: it contains citizen-authored text via the PR title.

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -310,6 +310,25 @@ def test_config_reads_the_environment() -> None:
 # --- cli ------------------------------------------------------------------
 
 
+def test_cli_dry_run_writes_no_ledger(tmp_path) -> None:
+    """The flag the workflow passes on every review.
+
+    It was added to cli.py and not to this entry point, so the first live run
+    after the change died on `unrecognized arguments: --dry-run`.
+    """
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(EVENT), encoding="utf-8")
+    out = tmp_path / "comment.md"
+
+    code = main(
+        ["--event", str(event_file), "--out", str(out), "--root", str(tmp_path), "--dry-run"]
+    )
+
+    assert code == 0
+    assert out.read_text(encoding="utf-8"), "the review is still composed"
+    assert not citizen_path("octocat", tmp_path).exists(), "and no state was written"
+
+
 def test_cli_writes_the_body_to_a_file_and_not_to_stdout(tmp_path, capsys) -> None:
     """The body carries a citizen-authored title; it must not be echoed into a log."""
     event_file = tmp_path / "event.json"


### PR DESCRIPTION
## Changes Summary

#42 said it could not be fully tested before merging, because the merge event was the thing under test. It merged, and **both halves failed.**

### 1. `unrecognized arguments: --dry-run`

`--dry-run` was added to `cli.py`. The workflow calls `python -m shodann.review`, which is a different entry point and had never heard of the flag. Every review since #42 landed has died at argument parsing, before composing anything.

The flag now exists where it is used, and a test exercises **the exact argv the workflow passes** — not a hand-written approximation of it.

### 2. `A branch or tag with the name 'fix/ledger-on-merge' could not be found`

Merging with `--delete-branch` removes the head branch before the `closed` event is handled. The checkout step was asking for `head.ref` by name, so the job died at checkout — **before any step could decide it did not need that branch.**

Checkout now takes the base ref on a closed event, which is where the ledger belongs anyway:

```yaml
ref: >-
  ${{ github.event.action == 'closed'
      && github.event.pull_request.base.ref
      || github.event.pull_request.head.ref }}
```

The record step drops its own now-redundant `git fetch` and `git checkout`.

## Related Issues

- Fixes the workflow shipped in #42
- Relates to #25

## Component(s) Affected

- [x] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [ ] Persona/Voice System
- [x] State Management
- [ ] Templates
- [ ] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 209 passed, 3 skipped, ruff clean.

`test_cli_dry_run_writes_no_ledger` passes the same argument list the workflow does and asserts both halves: the review is still composed, and no ledger is written. The gap that caused this was precisely that no test ran the CLI the way CI runs it.

The workflow was parsed with PyYAML to confirm the conditional ref expression resolves rather than being a string that merely looks right.

**Still only provable on merge.** The same caveat applies as last time, and it is the honest one: a workflow whose trigger is the merge event cannot be exercised by the pull request that changes it. The evidence will be a green `closed` run and a ledger commit landing on `main`.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

The checkout comment records *why* the ref is conditional, because the expression looks like defensive noise until you know a deleted branch fails the whole job.

## Educational Impact Assessment

### Student-Facing Changes

Every review since #42 merged has failed at argument parsing, so **students would have received nothing at all** — no comment, no fallback, no REDUCED ALLOCATION notice. The degradation ladder does not help when the process dies before reaching it.

Worth noting for the design: this failed *outside* everything built to fail gracefully. `PRD.md` §8's graceful degradation covers the model being unavailable; it does not cover the program not starting. A CI failure is silent to a student, who simply sees no review and no reason.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

### Clearance Levels Affected

- [x] All levels

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**Neither defect was findable without merging**, and saying so plainly matters more than implying the fix arrived clean. The first needed the workflow to actually invoke the CLI; the second needed a branch to actually be deleted by an actual merge.

**One gap this leaves open, worth a follow-up rather than a rushed fix here:** a failed *workflow* is invisible to a citizen. Every failure mode inside the program degrades to a comment; a failure of the program produces silence. A student refreshing a PR cannot distinguish "SHODANN is thinking" from "SHODANN crashed twenty minutes ago". A job-level `if: failure()` step that posts a REDUCED ALLOCATION notice would close it, and that mode already exists for exactly this shape of problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)