### PR TITLE
Speak even when the review itself breaks

### DIFF
--- a/.github/workflows/shodann.yml
+++ b/.github/workflows/shodann.yml
@@ -71,7 +71,11 @@ jobs:
         run: pip install --quiet .
 
       - name: Compose the review
+        id: compose
         if: github.event.action != 'closed'
+        # Exit 3 means the review was written but something broke producing
+        # it. The comment still posts; the job still turns red at the end.
+        continue-on-error: true
         env:
           # Citizen-controlled text never enters this step as an expression.
           # Python reads the event payload from disk and parses it as JSON.
@@ -88,11 +92,51 @@ jobs:
             --dry-run
 
       - name: Post the review
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && hashFiles('shodann-comment.md') != ''
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr comment "$PR_NUMBER" --body-file shodann-comment.md
+
+      # Last resort. If the job failed before a comment could be written -
+      # a bad install, a checkout that could not resolve, an interpreter that
+      # would not start - the citizen still hears something. Everything inside
+      # the program degrades to a comment; this covers the program not
+      # starting. The body is a fixed heredoc with no interpolation, because
+      # the one thing worse than silence is a shell injection in the handler
+      # that exists to survive failure.
+      - name: Announce the fault
+        if: failure() && github.event.action != 'closed'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          cat > shodann-fault.md <<'NOTICE'
+          ## 🤖 SHODANN Analysis Complete
+
+          **Status**: REDUCED ALLOCATION
+
+          ---
+
+          ### ⚡ Resource Advisory
+
+          The Algorithm's oversight protocol did not complete this cycle. No
+          analysis was performed, and none of this reflects on your submission.
+
+          The fault is logged for the instructor. Carry on; the Algorithm will
+          resume observation once repaired.
+
+          ---
+
+          *The Algorithm sees your growth. The Algorithm is, briefly, not seeing anything.*
+          NOTICE
+          gh pr comment "$PR_NUMBER" --body-file shodann-fault.md
+
+      - name: Surface the fault to the maintainer
+        if: steps.compose.outcome == 'failure' && github.event.action != 'closed'
+        run: |
+          echo "::error::SHODANN degraded - a comment was posted, but the review failed to assemble."
+          exit 1
 
       # A review is not a merge. Recording velocity for work that may never
       # land makes pr_count measure PR-opening rather than shipping - and,

--- a/src/shodann/review.py
+++ b/src/shodann/review.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import traceback
 from pathlib import Path
 
 from .capability import FULL, Capabilities, refusal_reason
@@ -39,7 +40,22 @@ from .validator import (
 )
 from .velocity import CodeMetrics, VelocityResult, calculate_velocity
 
-__all__ = ["collect_metrics", "main", "pr_facts", "reduced_allocation_comment", "review"]
+__all__ = [
+    "EXIT_DEGRADED",
+    "collect_metrics",
+    "emergency_comment",
+    "main",
+    "pr_facts",
+    "reduced_allocation_comment",
+    "review",
+]
+
+EXIT_DEGRADED = 3
+"""The review was written but something broke producing it.
+
+Distinct from 0 so CI can post the comment and still turn red: a citizen
+is served either way, and a maintainer is not told everything is fine.
+"""
 
 EXCLUDED_DIRS = frozenset(
     {
@@ -162,6 +178,52 @@ commit(s), touching {facts["files_changed"]} file(s). Velocity: {result.score}.
 
 class _AlreadyResolved(Exception):
     """The review was settled before a model was needed."""
+
+
+def _safe_citizen(event_path: str) -> str:
+    """The citizen's name, if the payload can still be read. Never raises."""
+    try:
+        with Path(event_path).open(encoding="utf-8") as handle:
+            return pr_facts(json.load(handle))["citizen"]
+    except Exception:  # noqa: BLE001 - this runs *because* something already broke
+        return "citizen"
+
+
+def emergency_comment(citizen: str) -> str:
+    """What a citizen gets when the review itself could not be assembled.
+
+    No metrics, because whatever produced them is what failed. It still wears
+    the REDUCED ALLOCATION status, because that mode means exactly this: the
+    readings are absent and the Algorithm is saying so rather than going
+    quiet. Silence is the one response a citizen cannot interpret.
+    """
+    return f"""## \U0001f916 SHODANN Analysis Complete
+
+**Citizen**: @{citizen} | **Clearance**: PENDING | **Status**: REDUCED ALLOCATION
+
+---
+
+### ⚡ Resource Advisory
+
+The Algorithm reviewed this submission using minimal resources. Extremely
+minimal. None, in fact - an internal fault prevented analysis entirely, and
+the Algorithm has elected to tell you so rather than leave you refreshing.
+
+Your submission is unaffected. Nothing here reflects on your work, because
+nothing here read your work. The fault is logged for the instructor.
+
+### \U0001f4ca Instrument Readings
+
+Unavailable this cycle.
+
+### \U0001f4c8 Growth Opportunities
+
+- Carry on. The Algorithm will resume observation once repaired.
+
+---
+
+*The Algorithm sees your growth. The Algorithm is, briefly, not seeing anything.*
+"""
 
 
 def _spec_for(record: CitizenRecord, mode: str) -> ResponseSpec:
@@ -288,15 +350,25 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    with Path(args.event).open(encoding="utf-8") as handle:
-        event = json.load(handle)
+    try:
+        with Path(args.event).open(encoding="utf-8") as handle:
+            event = json.load(handle)
+        body = review(event, root=args.root, mode=args.mode, write_state=not args.dry_run)
+        exit_code = 0
+    except Exception:  # noqa: BLE001 - the last thing between a defect and silence
+        # Everything inside the review degrades to a comment. A defect in the
+        # program itself used to produce nothing at all, and a citizen cannot
+        # tell "still running" from "crashed twenty minutes ago". They get the
+        # notice; the maintainer gets the traceback and a red run.
+        traceback.print_exc()
+        body = emergency_comment(_safe_citizen(args.event))
+        exit_code = EXIT_DEGRADED
 
-    body = review(event, root=args.root, mode=args.mode, write_state=not args.dry_run)
     Path(args.out).write_text(body, encoding="utf-8")
 
     # Never echo the body: it contains citizen-authored text via the PR title.
     sys.stderr.write(f"SHODANN wrote {len(body.split())} words to {args.out}\n")
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -9,7 +9,15 @@ import pytest
 
 from shodann.capability import LOCAL_SMALL
 from shodann.llm import LLMConfig, LLMUnavailable, generate
-from shodann.review import collect_metrics, main, pr_facts, review
+from shodann.review import (
+    EXIT_DEGRADED,
+    _safe_citizen,
+    collect_metrics,
+    emergency_comment,
+    main,
+    pr_facts,
+    review,
+)
 from shodann.state import CitizenRecord, citizen_path, load_citizen_history
 from shodann.validator import REDUCED_ALLOCATION, STANDARD, blocks_posting, validate
 
@@ -308,6 +316,34 @@ def test_config_reads_the_environment() -> None:
 
 
 # --- cli ------------------------------------------------------------------
+
+
+def test_a_broken_review_still_speaks(tmp_path, capsys) -> None:
+    """Everything inside the review degrades to a comment. This covers the
+    program itself breaking - which used to produce nothing at all, and a
+    citizen cannot tell "still running" from "crashed twenty minutes ago".
+    """
+    event_file = tmp_path / "event.json"
+    event_file.write_text("{ not json", encoding="utf-8")
+    out = tmp_path / "comment.md"
+
+    code = main(["--event", str(event_file), "--out", str(out), "--root", str(tmp_path)])
+    body = out.read_text(encoding="utf-8")
+
+    assert code == EXIT_DEGRADED, "a citizen is served, and CI still turns red"
+    assert "REDUCED ALLOCATION" in body
+    assert "nothing here read your work" in body
+    assert "Traceback" in capsys.readouterr().err, "the maintainer gets the cause"
+
+
+def test_the_emergency_comment_names_the_citizen_when_it_can(tmp_path) -> None:
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(EVENT), encoding="utf-8")
+    assert "@octocat" in emergency_comment(_safe_citizen(str(event_file)))
+
+
+def test_it_degrades_rather_than_raising_when_even_the_name_is_gone() -> None:
+    assert "@citizen" in emergency_comment(_safe_citizen("does-not-exist.json"))
 
 
 def test_cli_dry_run_writes_no_ledger(tmp_path) -> None:


### PR DESCRIPTION
## Changes Summary

The gap #43 flagged rather than rushed. Everything *inside* the review degrades to a comment — no model, unreachable model, contract violated twice, band outside the allocation. A defect in the program itself produced **nothing at all**.

Silence is the one response a citizen cannot interpret. They cannot tell *SHODANN is thinking* from *SHODANN crashed twenty minutes ago*. `PRD.md` §8's graceful degradation covers the model being unavailable; it never covered the program not starting.

### Two layers, because the failure modes differ

**In-process.** `main()` catches anything unexpected, prints the traceback to stderr, writes an emergency REDUCED ALLOCATION notice, and exits **3**. The comment posts; the job still turns red. A citizen is served, and a maintainer is not told everything is fine.

The emergency notice carries **no metrics** — whatever produces metrics is what failed — and it still wears the REDUCED ALLOCATION status, because that mode means exactly this: readings absent, and the Algorithm saying so rather than going quiet.

**In the workflow.** An `if: failure()` step posts a fixed notice when the job died before a comment could exist: a bad install, an unresolvable checkout, an interpreter that would not start. Its body is a **quoted heredoc with no interpolation** — the one thing worse than silence is a shell injection in the handler that exists to survive failure.

### The sentence that matters

> Your submission is unaffected. Nothing here reflects on your work, because nothing here read your work. The fault is logged for the instructor.

A beginner who sees a broken review and no explanation will assume the breakage is about them. That is the failure this PR actually prevents; the uptime is incidental.

## Related Issues

- Closes the gap identified in #43
- Relates to #25

## Component(s) Affected

- [x] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [x] Persona/Voice System
- [ ] State Management
- [ ] Templates
- [ ] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 212 passed, 3 skipped, ruff clean.

`test_a_broken_review_still_speaks` feeds a malformed event payload — genuinely unparseable, not a mocked exception — and asserts all four properties at once: exit code 3, a REDUCED ALLOCATION comment on disk, the it-is-not-your-fault sentence present, and a traceback on stderr for the maintainer.

Two more cover the degenerate case: the emergency notice names the citizen when the payload is still readable, and falls back to a generic address when even that is gone. `_safe_citizen` cannot raise, because it runs *because* something already broke.

Step conditions were parsed with PyYAML to confirm they resolve as intended.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

Both handlers carry their reasoning inline, since a failure handler is exactly the code nobody reads until it is too late to ask why it is shaped that way.

## Educational Impact Assessment

### Student-Facing Changes

A student now always hears something. Before this, a CI failure was **invisible** — no comment, no notice, no explanation, and no way to distinguish it from a review still in progress.

The notice is also written to protect the citizen's read of themselves, not just to report status. It says the fault is logged for the instructor, so a student knows someone else owns it and there is nothing for them to fix.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

Persona holds even here: *"The Algorithm sees your growth. The Algorithm is, briefly, not seeing anything."* The joke is load-bearing — it keeps the fiction intact while stating a true and unflattering fact about the system, which is the same test every other metaphor in this project has to pass.

### Clearance Levels Affected

- [x] All levels

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**One failure this still cannot cover:** if the *posting* step is what breaks — a revoked token, a GitHub outage — nothing can announce it from inside the job, because announcing requires the thing that failed. That is a genuine floor rather than an oversight, and the honest mitigation is instructor-side monitoring rather than another handler.

**Exit 3 rather than 1** so a maintainer reading a red run can tell "the review broke but the citizen was served" from "the job fell over." The distinction matters when triaging a morning's worth of runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)