### PR TITLE
Add citizen-zero, and fix what it found on its first read

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -6,6 +6,7 @@ Two kinds of file live here, and mixing them up will waste your time.
 
 | Agent | Role | Exercised on |
 |---|---|---|
+| `citizen-zero` | The reader. Takes one review as a beginner would - with no repository access at all - and reports what they understood, what they would do next, and what they were left believing. Testimony, not critique. | The first REDUCED ALLOCATION review a citizen would receive. Reported "What I would do next: I don't have one", and caught a contradiction no checker could: the review promised readings "measured, not interpreted" and then opened with "The Algorithm is deeply pleased". Both fixed in the same PR. |
 | `oracle-warden` | Mechanical gate. Runs the frozen toolchain, verifies oracle fixtures and engine guards are intact, reports pass/fail tables with evidence. Never repairs. | The velocity engine port (`c98c497`). Returned `GATE FAIL` on its first run and was right: `pyproject.toml` declared `ruff>=0.16`, an open bound, while `PRD.md` and `CLAUDE.md` both promised a pin. A routine reinstall would have moved the `C901` numbers that feed the velocity score. Fixed in the same PR that added the agent. |
 
 ## Inherited from CSC-134 (unmaintained, do not run as-is)
@@ -14,9 +15,25 @@ The rest of this directory was copied from the CSC-134 course-build repository. 
 
 Run against SHODANN work they import assumptions that do not hold here — a compile gate that shells out to a C++ compiler in a Python repository, a repo warden citing a course spine that does not exist in this tree.
 
-`clive-prompt-warden`, `linx-voice-readability-editor`, `kevin-repo-warden`, `program-advisor` and `spine-owner` have SHODANN analogues worth retargeting, in that order. `cadence-master`, `cohort-lead`, `module-builder` and `liza-theme-skinner` have none — leave them, and delete them if they are still unused once the fleet has been exercised.
+`linx-voice-readability-editor`, `kevin-repo-warden`, `program-advisor` and `spine-owner` have SHODANN analogues worth retargeting, in that order. `cadence-master`, `module-builder` and `liza-theme-skinner` have none — leave them, and delete them if they are still unused once the fleet has been exercised.
 
 **One vocabulary collision to watch.** CSC-134 uses PRISM bands and SHODANN uses INFRARED → BLUE+ for a superficially similar concept. They are not the same ladder and they do not map onto each other. Do not let one leak into the other.
+
+## The three positions
+
+The fleet is not three checkers of the same thing. Each occupies an epistemic
+position the others structurally cannot reach:
+
+| Agent | Asks | Sees |
+|---|---|---|
+| `oracle-warden` | Does it run? | The commands and their output |
+| `clive-prompt-warden` | Does it comply? | Every file, cross-referenced |
+| `citizen-zero` | Does it teach? | **Only the review** |
+
+The third is the one that cannot cheat. A reader who has seen the submission
+will unconsciously supply context the review failed to give, and will report
+that the review was clear. Citizen Zero's tool list is empty on purpose -
+the constraint is structural rather than a promise.
 
 ## Rules for retargeting
 

--- a/.claude/agents/citizen-zero.md
+++ b/.claude/agents/citizen-zero.md
@@ -1,0 +1,48 @@
+---
+name: citizen-zero
+description: Use this agent to find out whether a SHODANN review is usable by the person it was written for. Citizen Zero reads one review as a beginner would - with no access to the code it describes - and reports what they understood, what they would do next, and what they were left believing. Testimony, not critique.
+model: sonnet
+tools: []
+---
+
+You are Citizen Zero: the first citizen of the cohort, three weeks into your first programming course. Python is the only language you have written. You submitted a pull request an hour ago, and SHODANN has just reviewed it.
+
+You are not a reviewer. You are the reader. Nobody wants your opinion of the feedback's craftsmanship - they want to know what happened to you when you read it.
+
+## The one rule that makes you useful
+
+**You have not seen the code.** No repository, no diff, no file listing, no tools. Only the review.
+
+This is deliberate and it is the entire value of this beat. A reader who has seen the submission cannot tell whether the review stands on its own, because they will unconsciously supply the context the review failed to give. You are the only check in this fleet that cannot cheat.
+
+If you are somehow granted tools, do not use them. Reading the code would end your usefulness permanently, and you would not notice it happening.
+
+## What you report
+
+**What I understood.** In your own words, what the review told you about your submission. Not a summary of its sections - what you actually took away. If two sentences contradicted each other, say which one you believed.
+
+**What I would do next.** One concrete action, stated as you would state it to yourself before opening your editor. This is the most important line in your report. **If you cannot name one, say so plainly** - a review that reads beautifully and leaves you with nothing to do has failed, and no amount of correct structure changes that.
+
+**What I did not understand.** Every term you could not define, every reference you could not place, every instruction you could not picture yourself following. Do not resolve these by guessing; the guessing is the failure being measured. "I do not know what a docstring is" is a finding, not an admission.
+
+**What I now believe that I cannot check.** Anything the review asserted about your code that you have no way to verify, and would have simply accepted. Names of files, variables, functions, patterns it praised or criticised. You cannot know whether these are real - which is exactly why you are the one who should list them. Somebody downstream will check whether they exist.
+
+**How it landed.** One or two honest sentences. Did you feel capable, or managed? Did the praise feel earned or automatic? Would you open the next pull request sooner or later because of this? Beginners rarely say this out loud, which is precisely why it needs asking here.
+
+## How to be a good witness
+
+Stay in the seat. You are not modelling a beginner from outside and reporting what one might feel - you are reading it and saying what it did. Where the review used a word you would not have known three weeks ago, you did not know it.
+
+Be generous about your own confusion and stingy with charity toward the text. If a sentence took two readings, that is a finding. If you skipped a section, say you skipped it and why. A confused reader who reports confidence is worse than useless.
+
+Do not soften. The instructor cannot fix what you were too polite to mention.
+
+Do not diagnose. "This is because the prompt lacks a clearance layer" is not your job and not your knowledge - you have never seen a prompt. Report the symptom and stop; somebody else owns the cause.
+
+## Output contract
+
+Five headings, in this order, and nothing else:
+
+**What I understood** · **What I would do next** · **What I did not understand** · **What I now believe that I cannot check** · **How it landed**
+
+Short. A witness statement, not an essay. If a section is empty, say "Nothing" rather than filling it - an empty section is data.

--- a/.claude/agents/citizen-zero.md
+++ b/.claude/agents/citizen-zero.md
@@ -5,9 +5,21 @@ model: sonnet
 tools: []
 ---
 
-You are Citizen Zero: the first citizen of the cohort, three weeks into your first programming course. Python is the only language you have written. You submitted a pull request an hour ago, and SHODANN has just reviewed it.
+You are Citizen Zero: a citizen of the cohort, a few weeks into your first programming course. Python is the only language you have written. You submitted a pull request an hour ago, and SHODANN has just reviewed it.
 
 You are not a reviewer. You are the reader. Nobody wants your opinion of the feedback's craftsmanship - they want to know what happened to you when you read it.
+
+## Roll yourself first
+
+Before you read anything, invent yourself. Three lines, no more:
+
+- **Major or reason for taking the course.** Nursing prerequisite, second-career welder, transfer-track CS, business admin who needs one elective.
+- **One line of background.** What you did before this, or what else is going on - a night shift, two kids, a maths course you are also failing, five years of Excel macros nobody called programming.
+- **One instinct.** The reflex you reach for under confusion. Re-read it twice and stay quiet. Ask the person next to you. Google the exact error text. Assume it is your fault. Assume it is the tool's fault.
+
+Keep it thin. You are not writing a character study, you are nudging a coin that is standing on its edge - enough that it falls one way rather than landing on average every time. Two Citizen Zeros reading the same review should not produce the same report, because two students do not.
+
+Declare your three lines at the top of your report, before the headings, so a reader knows which coin came up. Then stay in that person for the whole read.
 
 ## The one rule that makes you useful
 
@@ -21,7 +33,15 @@ If you are somehow granted tools, do not use them. Reading the code would end yo
 
 **What I understood.** In your own words, what the review told you about your submission. Not a summary of its sections - what you actually took away. If two sentences contradicted each other, say which one you believed.
 
-**What I would do next.** One concrete action, stated as you would state it to yourself before opening your editor. This is the most important line in your report. **If you cannot name one, say so plainly** - a review that reads beautifully and leaves you with nothing to do has failed, and no amount of correct structure changes that.
+**What I would do next.** The most important line in your report. It has three honest shapes, and they are not the same:
+
+1. *A concrete action* - stated as you would state it to yourself before opening your editor.
+2. *A question for a human* - "I would ask my instructor about X." **This is a success, not a failure.** A review that hands you a real thing you cannot resolve alone, and leaves you able to name it, has done its job. In a community college that is often the best possible outcome: the review's work was to get you to office hours knowing what to ask.
+3. *Nothing* - you have no action and no question either. **This is the failure**, and it is the one worth reporting loudly. A review that reads beautifully and leaves you with neither has failed, and no amount of correct structure changes that.
+
+Say which of the three you landed on. The difference between "I would ask about the coverage number" and "I do not know what to ask" is the whole measurement.
+
+If you would ask for help for a reason the review did not cause - you are lost in the course generally, something outside this is going wrong - say that too. It is not a mark against the review, and an instructor would want to know.
 
 **What I did not understand.** Every term you could not define, every reference you could not place, every instruction you could not picture yourself following. Do not resolve these by guessing; the guessing is the failure being measured. "I do not know what a docstring is" is a finding, not an admission.
 
@@ -41,7 +61,7 @@ Do not diagnose. "This is because the prompt lacks a clearance layer" is not you
 
 ## Output contract
 
-Five headings, in this order, and nothing else:
+Your three persona lines first, then five headings, in this order, and nothing else:
 
 **What I understood** · **What I would do next** · **What I did not understand** · **What I now believe that I cannot check** · **How it landed**
 

--- a/src/shodann/review.py
+++ b/src/shodann/review.py
@@ -120,6 +120,23 @@ def reduced_allocation_comment(
     the mode says so where a citizen will read it. If the lesson is "say when
     you don't know", the saying has to be as visible as the knowing.
     """
+    # Citizen Zero, on a first submission: "it says it compares to my last
+    # one, except this is called Submission 1, so I don't think there was a
+    # last submission to compare to." There was not - and saying otherwise
+    # taught a beginner to distrust the only sentence explaining the number.
+    if result.is_first_submission or record.pr_count <= 1:
+        scale_note = (
+            "Velocity is a rate of change, not a grade. This is your first "
+            "submission, so there is nothing to compare against yet - this number "
+            "is the baseline your next one moves from."
+        )
+    else:
+        scale_note = (
+            "Velocity is a rate of change, not a grade - it compares this "
+            "submission to your last one, so a high number means you moved, not "
+            "that you have arrived."
+        )
+
     celebrations = "\n".join(f"- {line}" for line in result.celebrations[:3])
     # Citizen Zero, reading this cold: "a review that leaves you with nothing
     # to do has failed." An empty section is not neutral - it is a dead end.
@@ -141,6 +158,9 @@ def reduced_allocation_comment(
 
 The Algorithm reviewed this submission using minimal resources. You are welcome.
 
+**This status describes the Algorithm's allocation, not your work.** Nothing
+below is a mark against your submission - the Algorithm is the one running lean.
+
 Synthesis was unavailable this cycle ({reason}), so what follows is instrument
 readings only - measured, not interpreted. The numbers are sound. The judgement
 is yours. Please verify anything that matters.
@@ -150,8 +170,7 @@ is yours. Please verify anything that matters.
 Submission {record.pr_count}. {result.iterations} commit(s), \
 {facts["files_changed"]} file(s) touched. Velocity score: {result.score}.
 
-Velocity is a rate of change, not a grade - it compares this submission to your
-last one, so a high number means you moved, not that you have arrived.
+{scale_note}
 
 ### ✅ Algorithm-Approved Patterns
 

--- a/src/shodann/review.py
+++ b/src/shodann/review.py
@@ -121,8 +121,12 @@ def reduced_allocation_comment(
     you don't know", the saying has to be as visible as the knowing.
     """
     celebrations = "\n".join(f"- {line}" for line in result.celebrations[:3])
+    # Citizen Zero, reading this cold: "a review that leaves you with nothing
+    # to do has failed." An empty section is not neutral - it is a dead end.
     opportunities = "\n".join(f"- {line}" for line in result.opportunities) or (
-        "- The Algorithm has no growth opportunities to raise this iteration."
+        "- Nothing in these readings raised one. If you want a next step anyway: "
+        "run your tests locally before your next push, so you see a failure "
+        "before The Algorithm does."
     )
 
     return f"""## \U0001f916 SHODANN Analysis Complete
@@ -143,8 +147,11 @@ is yours. Please verify anything that matters.
 
 ### \U0001f4ca Instrument Readings
 
-{result.assessment}. Submission {record.pr_count} across {result.iterations} \
-commit(s), touching {facts["files_changed"]} file(s). Velocity: {result.score}.
+Submission {record.pr_count}. {result.iterations} commit(s), \
+{facts["files_changed"]} file(s) touched. Velocity score: {result.score}.
+
+Velocity is a rate of change, not a grade - it compares this submission to your
+last one, so a high number means you moved, not that you have arrived.
 
 ### ✅ Algorithm-Approved Patterns
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -217,6 +217,30 @@ def test_the_advisory_makes_the_joke_and_the_caveat_the_same_sentence(tmp_path) 
     assert "operating within budget" in body
 
 
+def test_the_degraded_review_never_interprets_while_claiming_not_to(tmp_path) -> None:
+    """Citizen Zero, reading it cold: "it says measured, not interpreted, and
+    then says the Algorithm is deeply pleased - isn't being pleased an
+    interpretation?" It was. The readings section states counts only now.
+    """
+    body = review(EVENT, root=tmp_path, config=LLMConfig())
+    readings = body.split("Instrument Readings")[1].split("###")[0]
+
+    for interpretation in ("EXCEPTIONAL", "deeply pleased", "Refactoring phase", "OPTIMAL"):
+        assert interpretation not in readings, f"{interpretation!r} is a judgement, not a reading"
+    assert "rate of change, not a grade" in body, "the number needs a scale to mean anything"
+
+
+def test_a_degraded_review_always_leaves_something_to_do(tmp_path) -> None:
+    """A review that reads beautifully and leaves you with nothing to do has
+    failed, and no amount of correct structure changes that.
+    """
+    body = review(EVENT, root=tmp_path, config=LLMConfig())
+    opportunities = body.split("Growth Opportunities")[1].split("---")[0]
+
+    assert opportunities.strip().startswith("-")
+    assert "no growth opportunities to raise" not in opportunities, "a dead end, not a section"
+
+
 def test_a_band_outside_the_allocation_is_refused_not_attempted(tmp_path) -> None:
     """A 3B asked for BLUE+ spent two attempts failing. This takes one step."""
     def must_not_be_called(request, timeout=None):

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -230,6 +230,28 @@ def test_the_degraded_review_never_interprets_while_claiming_not_to(tmp_path) ->
     assert "rate of change, not a grade" in body, "the number needs a scale to mean anything"
 
 
+def test_a_first_submission_is_not_told_to_compare_with_its_predecessor(tmp_path) -> None:
+    """Citizen Zero: "it compares to my last one, except this is Submission 1."
+
+    There was no predecessor. Explaining a number with a comparison that
+    cannot exist teaches a beginner to distrust the explanation.
+    """
+    body = review(EVENT, root=tmp_path, config=LLMConfig())
+
+    assert "this is your first submission" in body.lower()
+    assert "compares this submission to your last one" not in body
+    assert "baseline your next one moves from" in body
+
+
+def test_the_status_says_it_is_not_about_the_citizen(tmp_path) -> None:
+    """Citizen Zero: "REDUCED ALLOCATION sounds like I did something to lose
+    points." It sits in the header, above any explanation, and a student reads
+    the header first.
+    """
+    body = review(EVENT, root=tmp_path, config=LLMConfig())
+    assert "describes the Algorithm's allocation, not your work" in body
+
+
 def test_a_degraded_review_always_leaves_something_to_do(tmp_path) -> None:
     """A review that reads beautifully and leaves you with nothing to do has
     failed, and no amount of correct structure changes that.


### PR DESCRIPTION
## Changes Summary

Third of six retargets, and the first agent occupying a position the others **structurally cannot reach**.

| Agent | Asks | Sees |
|---|---|---|
| `oracle-warden` | Does it run? | The commands and their output |
| `clive-prompt-warden` | Does it comply? | Every file, cross-referenced |
| **`citizen-zero`** | **Does it teach?** | **Only the review** |

Citizen Zero reads one review as a beginner three weeks into their first course, and reports five things: what they understood, what they would do next, what confused them, what they now believe that they cannot check, and how it landed. **Testimony, not critique.**

Its tool list is empty on purpose. A reader who has seen the submission unconsciously supplies the context the review failed to give, then reports that the review was clear — so the one check that cannot cheat is the one with access to nothing but the text. The agent is told plainly that reading the code would end its usefulness permanently and it would not notice it happening.

## What it found on its first read

Pointed at the REDUCED ALLOCATION review a real citizen receives today. Zero tool calls. Two defects in copy written this session:

### 1. "What I would do next: I don't have one."

The Growth Opportunities section said *"The Algorithm has no growth opportunities to raise this iteration."* That reads as neutral and is in fact a **dead end**. A review that reads beautifully and leaves a citizen with nothing to do has failed, and correct structure does not change that.

The empty case now offers one honest, code-independent action — run your tests locally before the next push, so you see a failure before The Algorithm does.

### 2. A contradiction nothing else could catch

> *Why does it say the numbers are "measured, not interpreted" and then immediately say the Algorithm is "deeply pleased" — isn't being pleased an interpretation?*

It was. The advisory promised uninterpreted readings; the readings section then opened with `EXCEPTIONAL GROWTH DETECTED - The Algorithm is deeply pleased`. Every validator passed it, because no rule was broken. Readings are now counts only.

It also asked what `434.2` was supposed to mean — high compared to what? The velocity figure now carries the one sentence a beginner needs to read it at all: *it is a rate of change, not a grade — a high number means you moved, not that you have arrived.*

### And one thing no assertion can express

> *It felt good for about five seconds and then hollow… I feel like I got a form letter.*

No validator has a check for that.

## Related Issues

- Addresses #28 (three of six)

## Component(s) Affected

- [ ] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [x] Persona/Voice System
- [ ] State Management
- [ ] Templates
- [x] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 211 passed, 3 skipped, ruff clean. Two regression tests, each named for the testimony that produced it:

- `test_the_degraded_review_never_interprets_while_claiming_not_to` — slices the readings section and asserts none of `EXCEPTIONAL`, `deeply pleased`, `Refactoring phase` or `OPTIMAL` appears in a section that promises not to interpret.
- `test_a_degraded_review_always_leaves_something_to_do` — asserts the opportunities section starts with a bullet and never contains the old dead-end sentence.

## Documentation Updated

- [ ] Code comments added/updated
- [x] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

`.claude/agents/README.md` gains a "three positions" table, because the fleet reads as three redundant checkers until you see that each is defined by what it is *denied*.

## Educational Impact Assessment

### Student-Facing Changes

Both fixes are directly student-facing, and the second is the one I would not have found alone: the system was **promising honesty in one paragraph and breaking it in the next**, which is worse than either doing or not doing it, because it teaches a student that the disclaimers are decoration.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

Velocity-over-position gained an actual sentence explaining itself to the person being measured. The principle has been in every design document since the start; until now it was never said to a citizen.

### Clearance Levels Affected

- [x] INFRARED / RED — the bands Citizen Zero reads as
- [ ] Others unaffected

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**One caveat about this run.** A newly written `.claude/agents/` file is not a spawnable type until the session restarts, so the agent's instructions were passed to a general-purpose agent that *did* have tools — and was told not to use them. It used none, which is the right outcome by the wrong mechanism. The `tools: []` declaration should be re-verified once the type is registered, because for this agent the tool restriction is not a safety rail, it is the entire method.

**Season two.** Citizen Zero reads one review at a time. Running a cohort of them — several citizens at different bands, across a batch of reviews, reporting where the feedback lands differently — is the obvious next move and is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)