### PR TITLE
Measure at merge, so the ledger has coverage in it

### DIFF
--- a/.github/workflows/shodann.yml
+++ b/.github/workflows/shodann.yml
@@ -51,7 +51,14 @@ jobs:
   # =========================================================================
   analyse:
     name: Hard analysis
-    if: github.event.action != 'closed'
+    # Runs on merge too. The ledger is the durable baseline every later delta
+    # is measured from, and a record written without coverage means coverage
+    # can never move - the first merge under #47 recorded 0.0 and would have
+    # kept every future delta at zero. Measuring at merge is also the more
+    # honest reading: the record should describe what landed, not what the
+    # head looked like before it did. Skipped only for a pull request that
+    # closed without merging, where there is nothing to record.
+    if: github.event.action != 'closed' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -61,7 +68,13 @@ jobs:
       - name: Check out the submission
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          # Base on merge, head otherwise - the same rule the review job
+          # follows, and for the same reason: the head branch is usually
+          # already deleted by the time the closed event arrives.
+          ref: >-
+            ${{ github.event.action == 'closed'
+                && github.event.pull_request.base.ref
+                || github.event.pull_request.head.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -138,7 +151,8 @@ jobs:
         run: pip install --quiet .
 
       - name: Collect the readings
-        if: github.event.action != 'closed'
+        # On merge too: the ledger written below is the baseline the next
+        # submission is measured against.
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Changes Summary

The first merge under #47 recorded `coverage: 0.0`.

The `analyse` job was gated off the `closed` event, so the recording run skipped analysis, skipped the artifact download, and wrote a record with no coverage in it.

**That is worse than a missing number.** The ledger is the durable baseline every later delta is measured from. A record written without coverage keeps `previous.coverage` at zero forever — so the coverage weighting still never fires, and #47 would have shipped an instrument whose readings never reached the thing they instrument.

The `analyse` job now runs on merge as well, against the base branch. It stays skipped for a pull request closed *without* merging, where there is nothing to record.

## Measuring at merge is the better reading anyway

The record should describe **what landed**, not what the head looked like before it did. A PR-time measurement is taken against the head branch pre-merge; the merged tree can differ. Since the ledger's entire job is to be the baseline for the next comparison, it should measure the state that actually exists afterwards.

## Related Issues

- Fixes a defect shipped in #47
- Relates to #25

## Component(s) Affected

- [x] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [ ] Persona/Voice System
- [x] State Management
- [ ] Templates
- [ ] Documentation

## Testing Performed

- [x] Manual testing completed
- [ ] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 228 passed, 3 skipped, ruff clean — unchanged, since no Python changed. Job conditions parsed with PyYAML to confirm they resolve as written.

**Only provable on merge**, same as the changes it fixes. The evidence will be a non-zero `coverage` in `.shodann/citizens/norrisaftcc.json` on `main` after this lands — which is exactly the check that caught the defect.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

## Educational Impact Assessment

### Student-Facing Changes

Indirect and large. Without this, every citizen's coverage delta is computed against a stored zero forever, so a student going 40% → 55% would be scored as though they went 0% → 55% — an inflated reading on every submission, and the first-test weighting firing for someone on their tenth test.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

Velocity-over-position depends entirely on the previous reading being real. A baseline that is always zero measures position wearing the costume of a derivative.

### Clearance Levels Affected

- [x] All levels

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**Cost:** one extra test run per merge. Worth it — the alternative is a permanently zeroed baseline, and there is no cheaper way to measure the merged state than measuring the merged state.

**Second of two defects from #47's first live merge, being handled in serial.** The other is that the REDUCED ALLOCATION readout displays no coverage figure at all, instrumented or not, and is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)