### PR TITLE
Actually pass the readings to the review

### DIFF
--- a/.github/workflows/shodann.yml
+++ b/.github/workflows/shodann.yml
@@ -178,6 +178,7 @@ jobs:
             --event "$GITHUB_EVENT_PATH" \
             --out shodann-comment.md \
             --root . \
+            --reports shodann-reports \
             --dry-run
 
       - name: Post the review
@@ -241,7 +242,8 @@ jobs:
           python -m shodann.review \
             --event "$GITHUB_EVENT_PATH" \
             --out /tmp/shodann-record.md \
-            --root .
+            --root . \
+            --reports shodann-reports
           if [ -z "$(git status --porcelain .shodann)" ]; then
             echo "No ledger change to record."
             exit 0

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -1,0 +1,62 @@
+"""The workflow is code too, and nothing else in this suite can see it.
+
+Coverage instrumentation shipped, ran green, uploaded an artifact, downloaded
+it - and then never told the CLI where it was. The `--reports` flag was
+dropped by a silent string replacement, so every reading was discarded at the
+last step while every job reported success.
+
+These assertions are crude on purpose. They check that the workflow passes the
+arguments the program needs, which is exactly the class of defect that hides
+between a green CI run and a wrong number.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+WORKFLOW = Path(__file__).parent.parent / ".github" / "workflows" / "shodann.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_the_workflow_exists(workflow: str) -> None:
+    assert "SHODANN Educational Oversight Protocol" in workflow
+
+
+def test_both_invocations_are_told_where_the_readings_are(workflow: str) -> None:
+    """Downloading an artifact and not reading it is worse than not having one."""
+    invocations = workflow.count("python -m shodann.review")
+    assert invocations == 2, "one review, one record"
+    assert workflow.count("--reports shodann-reports") == invocations
+
+
+def test_the_review_never_writes_state(workflow: str) -> None:
+    """A review is not a merge. The ledger is written once, on close."""
+    assert "--dry-run" in workflow
+
+
+def test_the_analysis_job_holds_no_secrets(workflow: str) -> None:
+    """The job that runs a citizen's code must not be the job holding the key."""
+    analyse = workflow.split("analyse:")[1].split("  review:")[0]
+
+    assert "contents: read" in analyse
+    assert "secrets." not in analyse, "a hostile test cannot read a key that is not mapped"
+    assert "pytest" in analyse, "and it is the job that runs the tests"
+
+
+def test_the_review_job_never_runs_citizen_code(workflow: str) -> None:
+    review = workflow.split("  review:")[1]
+
+    for runner in ("pytest", "ruff check"):
+        assert runner not in review, f"{runner} belongs in the unprivileged job"
+
+
+def test_no_citizen_text_is_interpolated_into_a_shell(workflow: str) -> None:
+    """The defect in design_docs/shodann-core.yml:131, asserted against."""
+    for field in ("pull_request.title", "pull_request.body"):
+        assert f"${{{{ github.event.{field} }}}}" not in workflow


### PR DESCRIPTION
## Changes Summary

**My diagnosis in #48 was incomplete.** Gating the `analyse` job off the closed event was a real defect and worth fixing — but it was not why coverage never appeared.

The workflow uploaded `coverage.json`, downloaded it into `shodann-reports/`, and **then never told the CLI it was there.** The `--reports` flag was dropped by a string replacement that failed silently in the edit script that wrote #47.

Nothing caught it. Every job reported success. The artifact changed hands correctly. The readings were discarded at the final step, and the ledger recorded `coverage: 0.0` twice in a row while two green pipelines said everything was fine.

## The workflow was the one piece of code no test could see

That is the shape of defect this repository keeps producing — **green everywhere, wrong at the end** — and it has now happened three times in the workflow specifically: the `--dry-run` flag added to the wrong entry point, the checkout asking for a deleted branch, and now this.

Every one was a *contract between the workflow and the program*, and the suite had no way to observe that contract at all. So it does now.

`tests/test_workflow_contract.py` asserts, crudely and on purpose:

| Assertion | The defect it prevents |
|---|---|
| Both invocations pass `--reports` | This PR |
| The review still passes `--dry-run` | The ledger churn from #42 |
| `analyse` declares `contents: read` and references **no** secrets | A hostile test reading the model key |
| `review` invokes neither `pytest` nor `ruff check` | Citizen code creeping into the privileged job |
| No `pull_request.title`/`body` interpolated into a shell | `design_docs/shodann-core.yml:131`, asserted rather than described |

The security properties in that table were previously guaranteed by a comment explaining the intent. They are now guaranteed by a test that fails if someone moves a step.

## Related Issues

- Completes the fix begun in #48
- Fixes a defect shipped in #47

## Component(s) Affected

- [x] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [ ] Persona/Voice System
- [x] State Management
- [ ] Templates
- [ ] Documentation

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:** 234 passed, 3 skipped, ruff clean. Six new tests, all reading the workflow file as text.

They are deliberately not sophisticated. A YAML-aware assertion about step semantics would have been more elegant and would not have caught this — the failure was a missing string in a `run:` block, and the check that catches it is looking for that string.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

## Educational Impact Assessment

### Student-Facing Changes

Coverage begins to exist. Until this lands, every citizen's coverage reading is `0.0` regardless of what their tests actually cover, which means the heaviest term in the velocity engine has never once contributed to a real review.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

### Clearance Levels Affected

- [x] All levels

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above
- [x] Educational impact assessed above

## Additional Notes

**On how this was found:** I asserted a cause in #48, fixed it, merged it, and the symptom persisted. The ledger check that had caught the original defect caught the incomplete fix too — which is the argument for verifying after merge rather than declaring victory at the merge button.

**The second triage item is still open:** the REDUCED ALLOCATION readout displays no coverage figure at all, so even once this lands, a citizen at 62% will not see 62% anywhere in their review. That is next, and it is now the only known defect outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)