### PR TITLE
Show the citizen their coverage, and stop the score contradicting it

### DIFF
--- a/design_docs/EARLY_RUNS.md
+++ b/design_docs/EARLY_RUNS.md
@@ -155,9 +155,41 @@ Three reasons this file exists:
 
 ---
 
+## 8. The workflow was the one file no test could read
+
+**Where:** the first merge with coverage instrumentation. The ledger recorded `coverage: 0.0` after a run whose analysis job measured 98.6% and uploaded it.
+
+**The wrong diagnosis, and it was mine:** the analysis job was skipped on the `closed` event, so the merge that wrote the ledger had no readings to write. That was true, it was fixed, and the symptom survived it. Asserting a cause and merging a fix is not the same as confirming one.
+
+**The actual cause:** `--reports` was never passed to the CLI. A string replacement in the edit script that added the flag had failed silently, so the workflow uploaded the artifact, downloaded the artifact, and then invoked a review that had no idea it existed. Two green pipelines, correct artifact handoff, readings discarded at the last step.
+
+**The pattern this completes:** the third defect of the same shape, after a `--dry-run` flag added to the wrong entry point and a checkout asking for a branch that merge had deleted. All three were contracts *between the workflow and the program*, and the workflow was the only code in the repository no test could see.
+
+**What changed:** `tests/test_workflow_contract.py` reads the workflow as text and asserts crudely — both invocations pass `--reports`, the review still passes `--dry-run`, `analyse` declares `contents: read` and names no secret, `review` invokes neither `pytest` nor `ruff`, and no citizen-authored field reaches a shell. Those last two were previously guaranteed by a comment explaining the intent. A YAML-aware version would have been more elegant and would have caught none of this: the failure was a missing string in a `run:` block.
+
+---
+
+## 9. The comment contradicted itself about coverage
+
+**Where:** rendering the degraded review by hand, after the ledger finally held a real coverage figure. The tests were green.
+
+**What it said**, in one comment, three sections apart: *"Your previous submission was not measured, so this one starts the comparison"* under Instrument Readings, and *"Coverage jumped 98.6%! Significant testing investment"* under Algorithm-Approved Patterns. Also *"First tests are hardest tests"* — to a citizen who may have had 98.6% coverage all along.
+
+**Why:** `collect_metrics` has to hand the velocity engine a float, so an absent reading arrives as `0.0`. The engine cannot tell that zero from a measured one. The readout had just learned the difference; nothing downstream had. So the display refused to claim a gain while the score, the celebrations, and the opportunities all claimed it loudly.
+
+The same defect ran the other way and was worse: a citizen at 91.2% whose analysis job died scored **−405**, a 182-point punishment for a tool crashing. A punitive branch caused by infrastructure, which the behavioural contract forbids outright.
+
+**What changed:** `reconcile_coverage` holds coverage still unless *both* sides of the comparison were measured, and the ledger gained a `coverage_instrumented` flag so "nobody looked" and "no lines covered" stop sharing a representation. A measured zero is untouched — 0 to 30 is US-1.3's flagship case and must keep scoring as the gain it is.
+
+**How it was found:** by printing all seven branches and reading them. The assertion that would have caught it did not exist, because it never occurred to me that two sections of the same comment could disagree.
+
+---
+
 ## What the pattern says
 
-Every defect on this page needed the system to *run*. None was found by reading code, and the test suite was green through all of them — 136 passing tests while SHODANN told a citizen they had written twice as many tests as they had.
+Every defect on this page needed the system to *run*. None was found by reading code, and the test suite was green through all of them — 136 passing tests while SHODANN told a citizen they had written twice as many tests as they had; 243 while it told one their coverage jumped 98.6 points and, in the same comment, that there was nothing to compare against.
+
+Two of them were found by *rendering the output and reading it*, which is neither testing nor code review and appears in no methodology. It is the only technique on this page that caught a comment disagreeing with itself.
 
 The two agents caught different things and neither caught these: `oracle-warden` verifies what is checkable mechanically, `clive-prompt-warden` verifies what is consistent across documents. Neither can see what only appears when a real event payload meets a real runner.
 

--- a/src/shodann/review.py
+++ b/src/shodann/review.py
@@ -23,6 +23,7 @@ import argparse
 import json
 import sys
 import traceback
+from dataclasses import replace
 from pathlib import Path
 
 from .analysis import AnalysisReports
@@ -47,6 +48,7 @@ __all__ = [
     "emergency_comment",
     "main",
     "pr_facts",
+    "reconcile_coverage",
     "reduced_allocation_comment",
     "review",
 ]
@@ -129,8 +131,90 @@ def collect_metrics(
     )
 
 
+def reconcile_coverage(
+    metrics: CodeMetrics, record: CitizenRecord, reports: AnalysisReports
+) -> tuple[CodeMetrics, CodeMetrics | None]:
+    """Hold coverage still unless both sides of the comparison were measured.
+
+    A delta is a claim about the past. ``collect_metrics`` has to hand the
+    engine a float, so an absent reading arrives as 0.0 - and the engine, which
+    cannot tell that zero from a real one, then reports a 98-point gain to a
+    citizen whose coverage did not move (the instrument arrived) or a 91-point
+    collapse to one whose analysis job merely died. Both are punitive branches
+    caused by infrastructure, which the behavioural contract forbids.
+
+    So when either side is unmeasured, both sides are set to whichever figure
+    is real. The delta is zero, the celebrations stay quiet, and the score
+    stops swinging on whether a tool ran. A *measured* zero is untouched: 0 to
+    30 is US-1.3's flagship case and must keep scoring as the gain it is.
+
+    Returned rather than mutated, because the current metrics are also what
+    gets written to the ledger - and a cycle with no reading should carry the
+    last real figure forward rather than recording a zero that resets every
+    future delta.
+    """
+    previous = record.last_metrics
+    if reports.coverage_instrumented and (previous is None or record.coverage_instrumented):
+        return metrics, previous
+    if previous is None:
+        # No history and no reading: the baseline is already zero on both
+        # sides, so nothing can be inferred and nothing needs holding.
+        return replace(metrics, coverage=0.0), previous
+
+    anchor = metrics.coverage if reports.coverage_instrumented else previous.coverage
+    return replace(metrics, coverage=anchor), replace(previous, coverage=anchor)
+
+
+def _coverage_reading(reports: AnalysisReports, record: CitizenRecord, first: bool) -> str:
+    """One sentence of coverage, or one sentence saying there is none.
+
+    Coverage is the heaviest term in the velocity score and the one number a
+    citizen is most likely to be chasing. Leaving it out of the degraded
+    readout meant the review most citizens actually receive was silent about
+    the measurement it was most driven by.
+
+    A delta is only claimed when the previous figure was itself measured. A
+    stored zero from a cycle that never ran coverage is not a reading, and
+    subtracting from it would announce a gain the citizen did not make - the
+    same class of error as telling a first submission it compares to its
+    predecessor.
+    """
+    if not reports.coverage_instrumented:
+        return (
+            "Coverage: not measured this cycle. The coverage tool reported nothing, "
+            "which is a gap in the readings rather than a score of zero."
+        )
+
+    current = f"Coverage: {reports.coverage}% of lines run by your tests."
+    previous = record.last_metrics.coverage if record.last_metrics else None
+    if first or previous is None:
+        # A genuine first submission. US-1.3 treats this as a gain from zero
+        # and the celebrations say so, so the readout must not undercut them
+        # by implying the number means nothing yet.
+        return f"{current} This is your first measured reading."
+    if not record.coverage_instrumented:
+        # Not the same situation, and it needs its own sentence: there *is* a
+        # previous submission, it simply was never measured. Claiming a gain
+        # against it would credit the citizen for the instrument arriving.
+        return (
+            f"{current} Your previous submission was not measured, "
+            "so this one starts the comparison."
+        )
+
+    delta = round(reports.coverage - previous, 1)
+    if delta > 0:
+        return f"{current} \U0001f4c8 Up {delta} from {previous}%."
+    if delta < 0:
+        return f"{current} \U0001f4c9 Down {abs(delta)} from {previous}%."
+    return f"{current} Unchanged from {previous}%."
+
+
 def reduced_allocation_comment(
-    facts: dict, result: VelocityResult, record: CitizenRecord, reason: str
+    facts: dict,
+    result: VelocityResult,
+    record: CitizenRecord,
+    reason: str,
+    reports: AnalysisReports | None = None,
 ) -> str:
     """The review a citizen gets when nothing interpreted their readings.
 
@@ -147,7 +231,8 @@ def reduced_allocation_comment(
     # one, except this is called Submission 1, so I don't think there was a
     # last submission to compare to." There was not - and saying otherwise
     # taught a beginner to distrust the only sentence explaining the number.
-    if result.is_first_submission or record.pr_count <= 1:
+    first = result.is_first_submission or record.pr_count <= 1
+    if first:
         scale_note = (
             "Velocity is a rate of change, not a grade. This is your first "
             "submission, so there is nothing to compare against yet - this number "
@@ -160,6 +245,7 @@ def reduced_allocation_comment(
             "that you have arrived."
         )
 
+    coverage = _coverage_reading(reports or AnalysisReports(), record, first)
     celebrations = "\n".join(f"- {line}" for line in result.celebrations[:3])
     # Citizen Zero, reading this cold: "a review that leaves you with nothing
     # to do has failed." An empty section is not neutral - it is a dead end.
@@ -192,6 +278,8 @@ is yours. Please verify anything that matters.
 
 Submission {record.pr_count}. {result.iterations} commit(s), \
 {facts["files_changed"]} file(s) touched. Velocity score: {result.score}.
+
+{coverage}
 
 {scale_note}
 
@@ -317,8 +405,10 @@ def review(
         else AnalysisReports()
     )
     record = load_citizen_history(facts["citizen"], root)
-    metrics = collect_metrics(root, reports)
-    result = calculate_velocity(metrics, record.last_metrics, facts["commits"])
+    metrics, previous = reconcile_coverage(
+        collect_metrics(root, reports), record, reports
+    )
+    result = calculate_velocity(metrics, previous, facts["commits"])
 
     # The submission number this is about to become. State is written at the
     # end rather than here, because what gets recorded includes whether the
@@ -336,7 +426,7 @@ def review(
     if degradation:
         # Refused before a prompt is even assembled: no tokens, no latency,
         # and a reason a citizen can read.
-        body = reduced_allocation_comment(facts, result, record, degradation)
+        body = reduced_allocation_comment(facts, result, record, degradation, reports)
 
     try:
         if degradation:
@@ -366,11 +456,16 @@ def review(
         pass
     except LLMUnavailable as unavailable:
         degradation = str(unavailable)
-        body = reduced_allocation_comment(facts, result, record, degradation)
+        body = reduced_allocation_comment(facts, result, record, degradation, reports)
 
     if write_state:
         save_citizen_history(
-            facts["citizen"], metrics, result, root, degradation=degradation
+            facts["citizen"],
+            metrics,
+            result,
+            root,
+            degradation=degradation,
+            coverage_instrumented=reports.coverage_instrumented,
         )
     return body
 

--- a/src/shodann/state.py
+++ b/src/shodann/state.py
@@ -97,6 +97,17 @@ class CitizenRecord:
     velocity_history: list[dict] = field(default_factory=list)
     last_degradation: str | None = None
     """Why the most recent review went out uninterpreted, or None."""
+    coverage_instrumented: bool = False
+    """Whether ``last_metrics.coverage`` was measured or is a stand-in zero.
+
+    ``CodeMetrics.coverage`` cannot hold this: it is a float feeding an
+    arithmetic engine, and 0.0 there means both *no lines covered* and *nobody
+    looked*. Those two need to stay apart in the ledger, because the next
+    review subtracts from this number and would otherwise announce a 98-point
+    gain to a citizen whose coverage did not move - it was simply measured for
+    the first time. Defaults False, so ledgers written before coverage
+    instrumentation existed are correctly read as unmeasured.
+    """
 
     # -- serialisation -----------------------------------------------------
 
@@ -123,6 +134,7 @@ class CitizenRecord:
             velocity_trend=data.get("velocity_trend", TREND_NEW),
             velocity_history=list(data.get("velocity_history", [])),
             last_degradation=data.get("last_degradation"),
+            coverage_instrumented=bool(data.get("coverage_instrumented", False)),
         )
 
     def to_dict(self) -> dict:
@@ -142,6 +154,7 @@ class CitizenRecord:
             "velocity_trend": self.velocity_trend,
             "velocity_history": list(self.velocity_history),
             "last_degradation": self.last_degradation,
+            "coverage_instrumented": self.coverage_instrumented,
         }
 
 
@@ -197,6 +210,7 @@ def save_citizen_history(
     config: VelocityConfig = DEFAULT_CONFIG,
     now: str | None = None,
     degradation: str | None = None,
+    coverage_instrumented: bool = False,
 ) -> CitizenRecord:
     """Fold one submission into the citizen's ledger and write it atomically.
 
@@ -208,6 +222,9 @@ def save_citizen_history(
 
     record.pr_count += 1
     record.last_metrics = metrics
+    # Recorded beside the metrics it qualifies. A run whose analysis job died
+    # must not leave last cycle's measured reading looking current.
+    record.coverage_instrumented = coverage_instrumented
     record.last_velocity = result.score
     record.last_updated = timestamp
     record.baseline_established = True

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -20,6 +20,7 @@ from shodann.review import (
 )
 from shodann.state import CitizenRecord, citizen_path, load_citizen_history
 from shodann.validator import REDUCED_ALLOCATION, STANDARD, blocks_posting, validate
+from shodann.velocity import CodeMetrics
 
 EVENT = {
     "pull_request": {
@@ -269,6 +270,202 @@ def test_a_degraded_review_always_leaves_something_to_do(tmp_path) -> None:
 
     assert opportunities.strip().startswith("-")
     assert "no growth opportunities to raise" not in opportunities, "a dead end, not a section"
+
+
+# --- coverage in the degraded readout -------------------------------------
+#
+# The readout most citizens actually receive was silent about the measurement
+# the velocity score is most driven by. A citizen at 98.6% saw no coverage
+# figure anywhere in their review.
+
+
+def instrumented(tmp_path, percent: float) -> str:
+    """A coverage report of the shape the analysis job uploads."""
+    directory = tmp_path / "reports"
+    directory.mkdir(exist_ok=True)
+    (directory / "coverage.json").write_text(
+        json.dumps({"totals": {"percent_covered": percent}}), encoding="utf-8"
+    )
+    return str(directory)
+
+
+def ledger(tmp_path, *, coverage: float, measured: bool) -> None:
+    """A prior submission on record, with or without a real coverage reading."""
+    path = citizen_path("octocat", tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = CitizenRecord(
+        citizen="octocat",
+        pr_count=2,
+        baseline_established=True,
+        last_metrics=CodeMetrics(coverage=coverage, test_count=5),
+        coverage_instrumented=measured,
+    )
+    path.write_text(json.dumps(record.to_dict()), encoding="utf-8")
+
+
+def readings_of(body: str) -> str:
+    return body.split("Instrument Readings")[1].split("###")[0]
+
+
+def test_a_measured_coverage_figure_reaches_the_citizen(tmp_path) -> None:
+    body = review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 98.6), write_state=False,
+    )
+    assert "98.6%" in readings_of(body)
+
+
+def test_an_unmeasured_coverage_is_named_as_a_gap_not_a_zero(tmp_path) -> None:
+    """Absent is not zero, all the way to the sentence a student reads."""
+    body = review(EVENT, root=tmp_path, config=LLMConfig(), write_state=False)
+    readings = readings_of(body)
+
+    assert "not measured this cycle" in readings
+    assert "rather than a score of zero" in readings
+    assert "0.0%" not in readings, "an unmeasured reading must never print as a number"
+
+
+def test_a_first_submission_is_not_offered_a_comparison_it_cannot_have(tmp_path) -> None:
+    body = review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 30.0), write_state=False,
+    )
+    readings = readings_of(body)
+
+    assert "30.0%" in readings
+    assert "This is your first measured reading" in readings
+    assert "Up " not in readings, "there is nothing to be up from"
+
+
+def test_a_coverage_gain_is_stated_against_the_previous_figure(tmp_path) -> None:
+    ledger(tmp_path, coverage=62.5, measured=True)
+    body = review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 71.0), write_state=False,
+    )
+    assert "Up 8.5 from 62.5%" in readings_of(body)
+
+
+def test_a_coverage_drop_is_stated_plainly_and_without_reproach(tmp_path) -> None:
+    ledger(tmp_path, coverage=71.0, measured=True)
+    body = review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 62.5), write_state=False,
+    )
+    readings = readings_of(body)
+
+    assert "Down 8.5 from 71.0%" in readings
+    assert not blocks_posting(validate(body, REDUCED_ALLOCATION))
+
+
+def test_a_genuine_zero_to_thirty_is_a_gain_worth_stating(tmp_path) -> None:
+    """US-1.3's flagship case. A *measured* zero is a real starting point."""
+    ledger(tmp_path, coverage=0.0, measured=True)
+    body = review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 30.0), write_state=False,
+    )
+    assert "Up 30.0 from 0.0%" in readings_of(body)
+
+
+def test_a_stored_zero_that_nobody_measured_is_not_claimed_as_a_gain(tmp_path) -> None:
+    """The trap. Every ledger written before instrumentation holds 0.0, and
+    subtracting from it would tell a citizen their coverage rose 98 points on
+    the cycle it was first measured. It did not; the instrument arrived.
+    """
+    ledger(tmp_path, coverage=0.0, measured=False)
+    body = review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 98.6), write_state=False,
+    )
+    readings = readings_of(body)
+
+    assert "98.6%" in readings
+    assert "Up 98.6" not in readings
+    assert "previous submission was not measured" in readings, (
+        "a different situation from a first submission, and it needs its own sentence"
+    )
+
+
+def test_the_ledger_records_whether_coverage_was_measured(tmp_path) -> None:
+    review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 44.0),
+    )
+    assert load_citizen_history("octocat", tmp_path).coverage_instrumented
+
+    review(EVENT, root=tmp_path, config=LLMConfig())
+    assert not load_citizen_history("octocat", tmp_path).coverage_instrumented, (
+        "a cycle whose analysis died must not leave the last reading looking current"
+    )
+
+
+def test_the_coverage_line_does_not_push_the_readout_over_its_budget(tmp_path) -> None:
+    ledger(tmp_path, coverage=62.5, measured=True)
+    body = review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 71.0), write_state=False,
+    )
+    assert not blocks_posting(validate(body, REDUCED_ALLOCATION))
+
+
+# --- the score has to agree with the readout ------------------------------
+#
+# Found by rendering the comment rather than by any assertion: the readings
+# section correctly refused to claim a gain while the celebrations two
+# sections down announced "Coverage jumped 98.6%!" - one comment stating both
+# that no comparison exists and that a large one does.
+
+
+def test_an_unmeasured_cycle_does_not_collapse_the_score(tmp_path) -> None:
+    """A dead analysis job is not a 91-point regression by the citizen."""
+    ledger(tmp_path, coverage=91.2, measured=True)
+    body = review(EVENT, root=tmp_path, config=LLMConfig(), write_state=False)
+
+    assert "Coverage dropped" not in body
+    assert "not measured this cycle" in readings_of(body)
+
+
+def test_the_instrument_arriving_is_not_celebrated_as_the_citizen_improving(
+    tmp_path,
+) -> None:
+    """The contradiction itself. Both sections must tell the same story."""
+    ledger(tmp_path, coverage=0.0, measured=False)
+    body = review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 98.6), write_state=False,
+    )
+    patterns = body.split("Approved Patterns")[1].split("###")[0]
+
+    assert "previous submission was not measured" in readings_of(body)
+    assert "jumped" not in patterns, "the readings deny the gain the celebration claims"
+    assert "First tests are hardest tests" not in patterns, (
+        "they may have had 98.6% all along; only the instrument is new"
+    )
+
+
+def test_a_measured_zero_to_thirty_still_scores_as_the_gain_it_is(tmp_path) -> None:
+    """The reconciliation must not flatten US-1.3's flagship case."""
+    ledger(tmp_path, coverage=0.0, measured=True)
+    body = review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 30.0), write_state=False,
+    )
+    assert "Up 30.0 from 0.0%" in readings_of(body)
+    assert "Coverage" in body.split("Approved Patterns")[1].split("###")[0]
+
+
+def test_an_unmeasured_cycle_carries_the_last_real_figure_forward(tmp_path) -> None:
+    """Recording a zero would reset every future delta - the #47 defect."""
+    review(
+        EVENT, root=tmp_path, config=LLMConfig(),
+        reports_dir=instrumented(tmp_path, 88.0),
+    )
+    review(EVENT, root=tmp_path, config=LLMConfig())
+
+    record = load_citizen_history("octocat", tmp_path)
+    assert record.last_metrics.coverage == 88.0, "the baseline survives a dead tool"
+    assert not record.coverage_instrumented, "carried forward, not freshly measured"
 
 
 def test_a_band_outside_the_allocation_is_refused_not_attempted(tmp_path) -> None:


### PR DESCRIPTION
Triage item 2, and the defect it was hiding.

## What was reported

The REDUCED ALLOCATION readout displayed no coverage figure. That readout is the review most citizens actually receive, so a citizen at 98.6% saw the number nowhere — it reached the prompt and the ledger, but never the page.

## What adding it exposed

The line went in, I rendered the comment, and it disagreed with itself:

> **Instrument Readings** — Coverage: 98.6% of lines run by your tests. Your previous submission was not measured, so this one starts the comparison.
>
> **Algorithm-Approved Patterns** — Coverage jumped 98.6%! Significant testing investment. · First tests are hardest tests. The Algorithm weights this one heavily.

Told to a citizen who may have had 98.6% coverage all along. Only the instrument was new.

`collect_metrics` has to hand the velocity engine a float, so an absent reading arrives as `0.0` and the engine cannot tell it from a measured one. The display had just learned the difference; the score, the celebrations, and the opportunities had not.

The same collapse ran the other way and was worse. A citizen at 91.2% whose analysis job died scored **−405** — a 182-point punishment for a tool crashing. A punitive branch caused by infrastructure, which the behavioural contract forbids outright.

## The fix

- **`reconcile_coverage`** holds coverage still unless *both* sides of the comparison were measured. A measured zero is untouched: 0 → 30 is US-1.3's flagship case and keeps scoring as the gain it is.
- **`CitizenRecord.coverage_instrumented`** records which kind of zero the ledger holds. `CodeMetrics.coverage` cannot carry this — it is a float feeding an arithmetic engine, and `0.0` there means both *no lines covered* and *nobody looked*.
- An unmeasured cycle **carries the last real figure forward** instead of writing a zero that resets every future delta — the defect that made #47 and #48 necessary.
- The readout separates three situations that were sharing one sentence: a genuine first submission, a previous submission nobody measured, and a tool that did not report this cycle.

## All seven branches, rendered

| Situation | Readings | Score |
|---|---|---|
| 91.2 → 98.6 | 📈 Up 7.4 from 91.2% | 16.89 |
| 71.0 → 62.5 | 📉 Down 8.5 from 71.0% | −21.14 |
| measured 0 → 30 (US-1.3) | 📈 Up 30.0 from 0.0% | 120.79 |
| instrument arrives | previous not measured, this one starts the comparison | 0.79 |
| analysis job died | not measured this cycle | 0.79 (was −405) |
| first submission | first measured reading | 123.09 |
| no coverage ever | not measured this cycle | 3.09 |

Every one inside the 250-word budget and passing the REDUCED_ALLOCATION contract.

## Notes

Found by printing the output and reading it — not by a test, and not by review. The assertion that would have caught it did not exist, because it had not occurred to me that two sections of the same comment could disagree. `design_docs/EARLY_RUNS.md` gains entries 8 and 9; the second is the one worth reading.

247 tests, ruff clean.

## Educational Impact Assessment

**Pedagogical Alignment**
- [x] Growth-positive framing — removes a 182-point penalty a citizen could not have caused
- [x] Clearance-appropriate — no band-specific behaviour changed
- [x] Persona-consistent — the readout still states counts, never judgements
- [x] Velocity-over-position — a delta is now only claimed when it is a fact about the past
- [x] No negative learning impact — the case fixed here taught a beginner to distrust the readings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
