### PR TITLE
Bootstrap a fresh session against the system that exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `src/shodann/` — the implementation. Velocity engine, prompt assembly, output validator, groundedness probe, clearance calibration, capability declaration, citizen ledger.
 - `.github/workflows/shodann.yml` — live, two jobs, posts a comment on every PR to this repo.
-- `tests/` — 247 tests, including golden tests against the JS oracle and contract tests that read the workflow YAML as text.
+- `tests/` — 249 tests, including golden tests against the JS oracle and contract tests that read the workflow YAML as text.
+- `design_docs/sprints/2026-07-28/` — one sprint, documented end to end: `01-candidates.md` (37 surveyed items, the live backlog), `02-prediction.md`, `03-treatment.md`, `04-retro.md`, `05-assay.md`.
+- `.claude/skills/the-algorithm/` — a vendored discipline, pinned by commit. **Never edited here.** See `design_docs/addenda/the-algorithm.md`.
 - `design_docs/growth-velocity.js` — the **reference oracle**, not the runtime. Kept so the port stays checkable. Do not extend it.
 - `design_docs/shodann-core.yml` — the historical 5-job draft. Never deployed, unsafe as written (see Landmines 1). Read it for the literal tool invocations; do not copy it.
 
 `README.md` is in-persona satire with no product content — never mine it for requirements.
 
-**`design_docs/EARLY_RUNS.md` is the highest-value file in the repo for a new session.** Nine defects found by running the system, every one of which the test suite was green through. Read it before trusting that a passing suite means the thing works.
+**`design_docs/EARLY_RUNS.md` is the highest-value file in the repo for a new session.** Eleven defects found by running the system, every one of which the test suite was green through. Read it before trusting that a passing suite means the thing works.
+
+**Addenda live in `design_docs/addenda/` and are linked from here.** This file has almost no slack — an assay found 161 of 190 sentences load-bearing, so a reader who skims loses instructions rather than filler. Put detail in an addendum and name it here. An unlinked addendum does not exist.
+
+| Addendum | Read it before |
+|---|---|
+| `design_docs/addenda/the-algorithm.md` | writing any plan or document a later session will act on |
 
 ### Source precedence when documents disagree
 
@@ -178,9 +186,12 @@ Knobs: `RAGE_LOTTERY_PERCENTAGE "10"`, `RAGE_TRIGGER_KEYWORDS`, `RAGE_FULL_SCAN_
 
 These were written against the specs, before the port. **3, 5, 6, 7 and 9 are resolved in `src/shodann/` and the shipped workflow** — they are kept because `design_docs/` still carries the defective versions and a fresh reading of those files will re-derive them. 1, 2, 4, 8 and 10 still bite.
 
-Two more, learned from running it:
+Four more, learned from running it:
 
-- **A green suite proves very little here.** Nine defects in `EARLY_RUNS.md`, all found by running the system, all with the suite passing — including three that were contracts *between the workflow YAML and the program*, which no test could see until `tests/test_workflow_contract.py` started reading the YAML as text.
+- **A green suite proves very little here.** Eleven defects in `EARLY_RUNS.md`, all found by running the system, all with the suite passing — including three that were contracts *between the workflow YAML and the program*, which no test could see until `tests/test_workflow_contract.py` started reading the YAML as text.
+- **Anything feeding the score must not be choosable by the citizen being scored.** `--cov=.` counted a student's own test files in the coverage denominator, and `ruff check` without `--isolated` let their `pyproject.toml` decide which rules were counted. Both were live; both are now asserted in `tests/test_workflow_contract.py`. This is the lines-of-code metric in a new unit — check any new signal against it before adding one.
+- **The freeze is a deadline, not a preference.** `PRD.md` §8 freezes the measurement set for cohort 1, so a defect in a *measurement* is free to fix today and impossible after the first real submission — fixing it later invalidates every student's history. Adding a signal stays legal mid-cohort; changing or removing one does not. Sort measurement work by that clock, not by value.
+- **The break-character rule is buried in both documents that carry it** — `design_docs/SHODANN_CLAUDE.md` at sentence 115 of 165 in a subordinate clause, `design_docs/SHODANN_VOICE_GUIDE.md` at 157 of 160. It governs student distress, academic integrity and accessibility, and a model assembling a prompt reads 150 lines of persona enthusiasm before reaching it. **Unfixed**; see `design_docs/addenda/the-algorithm.md`.
 - **Absent is not zero, everywhere.** An unmeasured coverage reading and a measured 0% are different facts, and collapsing them produced both a fabricated 98-point celebration and a −405 score for a citizen whose analysis job merely died. `AnalysisReports.coverage`, `CitizenRecord.coverage_instrumented` and `reconcile_coverage` exist to keep them apart; a delta is only claimed when both sides were measured. A *measured* zero is untouched — 0 → 30 is US-1.3's flagship case.
 
 1. **`shodann-core.yml` is unsafe to copy as-is.** Line 131 interpolates `PR_BODY="${{ github.event.pull_request.body }}"` straight into a `run:` block, and the PR title goes into the Gemini prompt at line 511. A student-authored body containing `$(…)` or backticks executes shell on a runner holding `contents: write`, `pull-requests: write`, and `GEMINI_API_KEY`. Move every student-controlled field into an `env:` mapping and reference it as `"$PR_BODY"`.
@@ -199,6 +210,9 @@ Two more, learned from running it:
 | Question | File |
 |---|---|
 | **What broke when it ran, and why** | `design_docs/EARLY_RUNS.md` |
+| **The live backlog — 37 surveyed items** | `design_docs/sprints/2026-07-28/01-candidates.md` |
+| How this repo negotiates, and the floor test | `design_docs/addenda/the-algorithm.md` |
+| Which documents are below floor, and where their operative sentences sit | `design_docs/sprints/2026-07-28/05-assay.md` |
 | Velocity math as shipped, guards, US-1.3 | `src/shodann/velocity.py` |
 | Citizen ledger, clearance names, atomic writes | `src/shodann/state.py` |
 | Output contract per mode, clearance overrides, forbidden vocabulary | `src/shodann/validator.py` |

--- a/design_docs/EARLY_RUNS.md
+++ b/design_docs/EARLY_RUNS.md
@@ -185,11 +185,50 @@ The same defect ran the other way and was worse: a citizen at 91.2% whose analys
 
 ---
 
+## 10. The citizen could raise their own velocity
+
+**Where:** a five-agent survey of the repository, 2026-07-28. Neither defect is in any Python file; both are two lines of workflow that no scope had reason to read together.
+
+**What was wrong:** the analysis job ran `pytest --cov=.` with no coverage configuration, so the *citizen's own test files* entered the coverage denominator. Test modules execute end to end, so they join the average at roughly 100%. Coverage is the 2.0-weighted term, the largest in the score. **A student raised their velocity by adding a test file that asserts nothing.**
+
+The same job ran `ruff check .` without `--isolated`, so ruff resolved configuration from the repository being analysed. The lint delta feeds the score through the `sqrt` term, which makes rule selection a score input rather than a style preference — and made lint counts incomparable between citizens.
+
+**Why it matters more than it reads:** this is the lines-of-code metric wearing a different unit. Measure LOC, get verbose code. Measure coverage without scoping it, get empty test files. A *rate* metric is easier to game than a position metric, because a citizen only has to move, not to be good — holding 90% honestly is work, adding one assertion-free file is thirty seconds.
+
+**The clock:** `PRD.md` §8 freezes the measurement set for cohort 1, because changing a measurement resets every baseline. Both were **free to fix that day and impossible a month later** — after the first real submission, correcting them means invalidating every student's history.
+
+**What changed:** `--cov=src` with a fallback for flat layouts, `ruff check --isolated`, and both asserted in `tests/test_workflow_contract.py`. The coverage test failed on its first run against the comment explaining why `--cov=.` is wrong — correct behaviour from a crude string check, and the reason the assertion now reads only executable lines.
+
+---
+
+## 11. Two documents buried the sentence that protects a student in distress
+
+**Where:** eight blind readers ran an external floor test — ASSAY, from the vendored `the-algorithm` skill — against one document each. None knew what SHODANN is or that the others existed.
+
+**What they found**, independently, in the two documents that carry the rule:
+
+- `SHODANN_CLAUDE.md` — *"It's okay to break character"*, sentence **115 of 165**, in a **subordinate clause**.
+- `SHODANN_VOICE_GUIDE.md` — *"The satire serves learning. When it doesn't, set it aside."*, sentence **157 of 160**.
+
+That rule governs student distress, academic-integrity concerns, and accessibility accommodation. It is the highest-consequence sentence in the corpus, and both documents that carry it place it last and place it down. A model assembling a prompt reads roughly 150 lines of persona enthusiasm before reaching the clause that says stop performing.
+
+**The control that makes this trustworthy:** `README.md` was included deliberately as in-persona satire with no product content. It returned below floor at 2 of 7 sentences. Had it come back clean, every other result would have been void.
+
+**The finding nobody predicted:** we agreed in advance to discount `SHODANN_VOICE_GUIDE.md` as a false positive, on the grounds that a document prescribing smoothness will read as smooth. **It came back above floor** — the instrument did not confuse deliberate persona with manufactured agreeableness. What it found instead was that 18 of 190 sentences carry load, the lowest ratio in the corpus: the document expands where it is fun and stays thin where it constrains.
+
+**And on `PRD.md`**, a reader given no dates flagged `smoothness-confined-to-a-graft`: sections 1–7 contain no sentence anyone could object to, while the §8 block added eighteen months later holds *"the only sentences with cost."* It located the seam between the generated document and the argued one without being told either existed.
+
+**Status: unfixed.** Recorded because ASSAY never redrafts — acting on it is separate work.
+
+---
+
 ## What the pattern says
 
 Every defect on this page needed the system to *run*. None was found by reading code, and the test suite was green through all of them — 136 passing tests while SHODANN told a citizen they had written twice as many tests as they had; 243 while it told one their coverage jumped 98.6 points and, in the same comment, that there was nothing to compare against.
 
 Two of them were found by *rendering the output and reading it*, which is neither testing nor code review and appears in no methodology. It is the only technique on this page that caught a comment disagreeing with itself.
+
+The last two needed a different move again: **reading with something withheld.** Entry 10 came from five surveyors who each saw one scope and could not see the others, plus a critic asked only what falls between them. Entry 11 came from readers who were given a document and denied any knowledge of what it was for. Every technique on this page works by removing context from the reader — running the system removes the author's knowledge of what it *should* do, and a blind read removes the reader's ability to supply what the document failed to say. A reviewer who knows the intent will unconsciously fill the gap and report that there wasn't one.
 
 The two agents caught different things and neither caught these: `oracle-warden` verifies what is checkable mechanically, `clive-prompt-warden` verifies what is consistent across documents. Neither can see what only appears when a real event payload meets a real runner.
 

--- a/design_docs/addenda/the-algorithm.md
+++ b/design_docs/addenda/the-algorithm.md
@@ -1,0 +1,89 @@
+# Addendum — The Algorithm, vendored
+
+Linked from `CLAUDE.md`. Read this before writing a plan, a PRD section, or any
+document a future session will act on.
+
+## What it is
+
+`.claude/skills/the-algorithm/` holds a vendored copy of `norrisaftcc/the-algorithm`,
+pinned in `PROVENANCE.md`. **Never edit it here.** Amend upstream, through its
+own gate, then re-vendor and update the commit.
+
+It is a discipline for working with language models under a gate: **negotiate,
+freeze, execute, verify.** It has two operations and no others.
+
+- **PROVIDE** — compress a draft prompt to the shortest version that clears a
+  floor test, freeze it at a gate, execute exactly as frozen.
+- **ASSAY** — run the floor test against a *received* document. Report what
+  survives. Read-only, never redrafted.
+
+## The floor
+
+Four nouns. A document or prompt is above the floor when all four are stated or
+clearly inferable, and a capable receiver gets it right first try more than half
+the time.
+
+**Audience · Scope · Format · Path**
+
+`Path` means the exact path of every file produced. It is automatic when no file
+is produced, and it is the item this repository's own documents fail most often.
+
+## The gate, which governs how work is negotiated here
+
+- Only a human opens it. Freezing verbs only — "freeze", "execute", "run it".
+- **Praise, thanks, "sounds good", and silence open nothing.** No completion assist.
+- The gate question is valid only immediately below the full contract text. No
+  gating by reference.
+- Negotiation side revises. Execution side executes exactly. There is no third
+  side where things get quietly fixed.
+- A failed execution names its floor item and reopens the contract.
+
+**Seats:** Customer, Facilitator, Peer, Algorithm. A person may hold several; an
+utterance holds exactly one. Name the seat before speaking from it when more than
+one is in play. Unmarked seat-switching is how tacit requirements stay tacit.
+
+## Language lock — ASD-STE100
+
+All Algorithm output conforms to Simplified Technical English. One word per
+meaning. At most 20 words per instruction. Active voice. Imperative mood. No
+idioms. `HOUSE-STYLE.md` beside the skill carries the vendored subset.
+
+Only `design_docs/sprints/2026-07-28/04-retro.md` in this repository is written
+to that lock. The rest is not, deliberately — rewriting them would hide the
+finding.
+
+## What it found here, 2026-07-28
+
+Eight blind readers, one document each. Full results in
+`design_docs/sprints/2026-07-28/05-assay.md`.
+
+| Document | Floor | Load-bearing |
+|---|---|---|
+| `README.md` *(control)* | below | 2 of 7 |
+| `design_docs/SHODANN_CLAUDE.md` | below | 58 of 165 |
+| `prompts/01_base_shodann_prompt.md` | below | 48 of 90 |
+| `design_docs/SHODANN_VOICE_GUIDE.md` | above | 18 of 190 |
+| `design_docs/RAGE_STATE.md` | above | 25 of 113 |
+| `PRD.md` | above | 76 of 195 |
+| `CLAUDE.md` | above | 161 of 190 |
+
+Three findings worth carrying:
+
+1. **The break-character rule is buried in both documents that carry it** —
+   `SHODANN_CLAUDE.md` at sentence 115 of 165 in a *subordinate clause*, and
+   `SHODANN_VOICE_GUIDE.md` at 157 of 160. It governs student distress, academic
+   integrity, and accessibility. It is the highest-consequence sentence in the
+   corpus and both documents put it last. **Unfixed.**
+2. **`SHODANN_CLAUDE.md` fails Path outright.** Every file is a bare filename;
+   all five Common Task recipes open unresolvable. **Unfixed.**
+3. **`CLAUDE.md` has no slack.** 161 of 190 sentences carry load, so a reader who
+   skims loses instructions rather than filler. That is why detail belongs in
+   this folder and not inline. Its decisions are also passive and agentless —
+   "is resolved", "decided 2026-07-25". No decider is ever named.
+
+## When to reach for it
+
+- Before writing a plan a future session will follow — run PROVIDE, hit the gate.
+- Before trusting a document you did not write — run ASSAY.
+- **ASSAY never redrafts.** Acting on its findings is a new PROVIDE, with the
+  peer in the customer seat, starting from the scene rather than from the residue.


### PR DESCRIPTION
Executed under the contract frozen at the gate. Every listed item, nothing else.

## What a fresh session now gets

`CLAUDE.md` stays the only bootstrap. The assay found it at **161 of 190 load-bearing** — no slack — and the reader declined to call that a compliment: *"a receiver who skims loses instructions rather than filler."* So this adds little inline and pushes detail to `design_docs/addenda/`, named from the bootstrap. An unlinked addendum does not exist.

Added inline:
- The sprint directory and what each of its five files holds, with `01-candidates.md` named as the live backlog.
- The vendored skill, its location, and the rule that it is never edited here.
- Four landmines from running the system, including **anything feeding the score must not be choosable by the citizen being scored**, and **the freeze is a deadline, not a preference** — a measurement defect is free today and impossible after the first real submission.

## `EARLY_RUNS.md` entries 10 and 11

**10 — the citizen could raise their own velocity.** `--cov=.` counted their own test files in the denominator; `ruff check` without `--isolated` let their config decide which rules counted. Both fixed and asserted this sprint.

**11 — two documents buried the sentence that protects a student in distress.** `SHODANN_CLAUDE.md` at 115 of 165 in a subordinate clause; `SHODANN_VOICE_GUIDE.md` at 157 of 160. **Marked unfixed**, because ASSAY never redrafts and acting on it is separate work.

The closing note now names what all eleven have in common: every one was found by **removing context from the reader** — a blind scope, a blind read, or running the system. A reviewer who knows the intent supplies what the artifact failed to say, then reports nothing was missing.

## Also

Issues #28, #51 and #52 updated against what this session decided — #51 gains the *channel* model, #52 gains live evidence that blind readers do not mistake deliberate persona for manufactured smoothness. Local clone moved to `the-algorithm`. Scratchpad deleted.

## Verification

```
249 passed, 3 skipped
All checks passed!
```

## Educational Impact Assessment

- [x] Not student-facing

🤖 Generated with [Claude Code](https://claude.com/claude-code)