### PR TITLE
Fix the measurements before the freeze makes them permanent

### DIFF
--- a/.github/workflows/shodann.yml
+++ b/.github/workflows/shodann.yml
@@ -106,7 +106,29 @@ jobs:
         # and the lint delta feeds the velocity score through the sqrt term -
         # so a student could raise their own velocity by editing their
         # pyproject.toml. Rule selection is a score input, not a preference.
-        run: ruff check . --isolated --output-format=json > ruff.json || true
+        #
+        # C90 has to be asked for, and asked for this way. --isolated discards
+        # the citizen's configuration and ours alike, and C901 is not in
+        # ruff's default set: run isolated against a function with twelve
+        # branches and it reports nothing at all. So the complexity metric PRD
+        # section 8 names was unreachable from the moment --isolated shipped,
+        # whatever any pyproject.toml said.
+        #
+        # --extend-select, never a bare --select. Replacing the default set
+        # would move `lint_issues`, which is a frozen score input feeding the
+        # sqrt term - on this repository a full explicit selection swung it
+        # from 19 to 0 in one direction and to 492 in the other. Extending
+        # leaves every existing count untouched and adds exactly one rule.
+        # Adding a signal is permitted mid-cohort; changing one is not.
+        #
+        # The threshold is set here rather than read from anywhere, for the
+        # same reason as --isolated: what counts as a violation is a score
+        # input, not a preference of the repository being measured.
+        run: >-
+          ruff check . --isolated
+          --extend-select C90
+          --config "lint.mccabe.max-complexity=10"
+          --output-format=json > ruff.json || true
 
       - name: Tests and coverage
         # Failing tests are data, not a broken job. A citizen whose suite is

--- a/.github/workflows/shodann.yml
+++ b/.github/workflows/shodann.yml
@@ -82,7 +82,14 @@ jobs:
           python-version: '3.12'
 
       - name: Install the frozen toolchain
-        run: pip install --quiet "ruff==0.16.0" pytest pytest-cov
+        # Every tool whose output reaches the velocity score carries an exact
+        # pin, and pytest-cov is the one that matters most: coverage is the
+        # 2.0-weighted term, the largest in the composite. It ran unpinned
+        # beside an exactly pinned ruff, so a coverage.py release could move
+        # every citizen's heaviest input mid-cohort with nothing to show for
+        # it in the diff. pytest itself stays open - test count is read from
+        # source, never from a run.
+        run: pip install --quiet "ruff==0.16.0" "pytest-cov==7.1.0" pytest
 
       - name: Install the submission
         # A citizen's project may or may not be installable. Neither outcome

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,18 @@ requires-python = ">=3.11"
 dependencies = ["jinja2>=3.1"]
 
 [project.optional-dependencies]
-# ruff is pinned exactly, pytest is not. ruff's C901 output feeds the velocity
-# score, and its numbers move between releases - an open bound would let a
-# routine reinstall reset every citizen's complexity baseline. pytest changes
-# nothing a citizen is measured on. Bumping the pin is a deliberate act that
-# ends a cohort's frozen window; see PRD section 8.
-dev = ["pytest>=8", "ruff==0.16.0"]
+# Exact pins are for tools whose output feeds the velocity score. A routine
+# reinstall must not move a citizen's baseline, so bumping one of these is a
+# deliberate act that ends a cohort's frozen window; see PRD section 8.
+#
+#   ruff        pinned - diagnostic counts feed the lint term, and C901 is the
+#               complexity metric. Its numbers move between releases.
+#   pytest-cov  pinned - coverage is the 2.0-weighted term, the largest in the
+#               composite. It was unpinned in CI and missing here entirely,
+#               while the lighter input beside it was pinned exactly.
+#   pytest      not pinned - nothing a citizen is measured on comes from it.
+#               Test count is read from source, never from a run.
+dev = ["pytest>=8", "pytest-cov==7.1.0", "ruff==0.16.0"]
 
 [project.scripts]
 shodann-velocity = "shodann.cli:main"

--- a/src/shodann/analysis.py
+++ b/src/shodann/analysis.py
@@ -23,9 +23,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 __all__ = [
+    "COMPLEXITY_RULE",
     "COVERAGE_REPORT",
     "LINT_REPORT",
     "AnalysisReports",
+    "read_complexity",
     "read_coverage",
     "read_lint_issues",
 ]
@@ -35,6 +37,17 @@ COVERAGE_REPORT = "coverage.json"
 
 LINT_REPORT = "ruff.json"
 """Written by `ruff check --output-format=json`."""
+
+COMPLEXITY_RULE = "C901"
+"""The one rule whose diagnostics are counted separately from the rest.
+
+PRD section 8 names C901 as SHODANN's complexity metric, replacing radon's
+Maintainability Index: "this function has 12 branches" is actionable, "your MI
+is 64" reads as a grade. Until this reader existed nothing anywhere consumed a
+C901 diagnostic - `collect_metrics` reported a count of `def ` under the name
+complexity - so the frozen ruff pin was protecting a number that was never
+computed.
+"""
 
 
 @dataclass(frozen=True)
@@ -49,6 +62,7 @@ class AnalysisReports:
 
     coverage: float | None = None
     lint_issues: int | None = None
+    complexity: int | None = None
     tests_passed: int | None = None
     tests_failed: int | None = None
 
@@ -61,9 +75,11 @@ class AnalysisReports:
         """Read whichever reports are present in ``directory``."""
         base = Path(directory)
         coverage, passed, failed = read_coverage(base / COVERAGE_REPORT)
+        lint_report = base / LINT_REPORT
         return cls(
             coverage=coverage,
-            lint_issues=read_lint_issues(base / LINT_REPORT),
+            lint_issues=read_lint_issues(lint_report),
+            complexity=read_complexity(lint_report),
             tests_passed=passed,
             tests_failed=failed,
         )
@@ -112,10 +128,41 @@ def read_lint_issues(path: Path | str) -> int | None:
     moved, never which rule they violated. Rule-level feedback belongs in the
     review's prose, where it can be explained.
     """
-    data = _load(path)
+    diagnostics = _diagnostics(_load(path))
+    return None if diagnostics is None else len(diagnostics)
+
+
+def _diagnostics(data) -> list | None:
+    """The diagnostic list, whichever shape ruff wrote it in."""
     if isinstance(data, list):
-        return len(data)
+        return data
     # Some ruff versions wrap diagnostics in an object.
     if isinstance(data, dict) and isinstance(data.get("diagnostics"), list):
-        return len(data["diagnostics"])
+        return data["diagnostics"]
     return None
+
+
+def read_complexity(path: Path | str) -> int | None:
+    """How many functions ruff found above the branch threshold.
+
+    This is a count of C901 *violations*, not total cyclomatic complexity.
+    ruff reports only what breaches `lint.mccabe.max-complexity`, so a
+    codebase of well-shaped functions reads 0 - which is the true and useful
+    answer, not a missing one. A citizen learns that no function is over the
+    line, or exactly how many are.
+
+    It does not feed the velocity score, deliberately. A positive delta here
+    means a citizen *added* an over-threshold function, and the growth term
+    would have paid them for it; see the note in `velocity.composite_score`.
+
+    ``None`` means ruff did not run or wrote something unreadable, which is
+    not the same as a clean codebase and must never be flattened into one.
+    """
+    diagnostics = _diagnostics(_load(path))
+    if diagnostics is None:
+        return None
+    return sum(
+        1
+        for item in diagnostics
+        if isinstance(item, dict) and item.get("code") == COMPLEXITY_RULE
+    )

--- a/src/shodann/config.py
+++ b/src/shodann/config.py
@@ -76,6 +76,24 @@ class VelocityConfig:
     Growing complexity without tests is a smaller credit, never a penalty.
     """
 
+    complexity_growth_reads_functions: bool = True
+    """Take the growth term from ``functions`` rather than ``complexity``.
+
+    A deliberate divergence from the oracle, expressed here rather than in the
+    engine so ``ORACLE_CONFIG`` still reproduces the retired JavaScript exactly
+    - the same mechanism ``first_test_bonus`` uses.
+
+    The oracle read ``complexity``. In production the two fields have always
+    held the same number, a count of ``def ``, because ``collect_metrics`` set
+    them from one variable. Now that ``complexity`` carries a real C901
+    reading, the term has to say which of the two it always meant: "how much
+    code did you take on", which is ``functions``. Pointing it at C901 instead
+    would credit a citizen for adding a function over the branch threshold.
+
+    Only the synthetic oracle fixtures ever set the two fields apart, so
+    flipping this changes no real citizen's score by any amount.
+    """
+
     max_opportunities: int = 2
     """Hard cap from the output contract. The engine truncates; job 4 must not have to."""
 
@@ -84,5 +102,8 @@ class VelocityConfig:
 
 DEFAULT_CONFIG = VelocityConfig()
 
-ORACLE_CONFIG = VelocityConfig(first_test_bonus=0.0)
+ORACLE_CONFIG = VelocityConfig(
+    first_test_bonus=0.0,
+    complexity_growth_reads_functions=False,
+)
 """Reproduces design_docs/growth-velocity.js. Test-only - never ship this."""

--- a/src/shodann/review.py
+++ b/src/shodann/review.py
@@ -123,7 +123,18 @@ def collect_metrics(
     return CodeMetrics(
         coverage=reports.coverage or 0.0,
         test_count=tests,
-        complexity=functions,
+        # C901 violations, from the report - not the `def ` count this field
+        # used to hold. The two were the same number for every reading ever
+        # taken, which is why `pyproject.toml` could claim the ruff pin
+        # protected a complexity baseline that nothing computed.
+        #
+        # A measured 0 here is a real and good answer: no function exceeds the
+        # branch threshold. An absent report also reads 0, exactly as
+        # `lint_issues` beside it does - tolerable only because nothing keyed
+        # on this can fabricate a claim from a zero. The score no longer reads
+        # it, and `_complexity_note` fires on a positive delta, so silence is
+        # what an unmeasured cycle produces.
+        complexity=reports.complexity or 0,
         loc=loc,
         functions=functions,
         docstrings=docstrings,

--- a/src/shodann/velocity.py
+++ b/src/shodann/velocity.py
@@ -140,6 +140,28 @@ def _coverage_multiplier(previous_coverage: float, config: VelocityConfig) -> fl
     return 1.0 + config.first_test_bonus * headroom
 
 
+def _growth_delta(deltas: MetricDeltas, config: VelocityConfig) -> int:
+    """Which delta the "complexity growth" term actually means.
+
+    It means "how much code did you take on", and it always did - until C901
+    was measured, `complexity` and `functions` were the same `def ` count set
+    from one variable, so the term's label and its input never had to agree.
+    Now they do. `functions` is the honest one.
+
+    Reading `complexity` instead would be worse than a mislabel: a positive
+    delta in a C901 count means the citizen *added a function over the branch
+    threshold*, and this term would pay them for it.
+
+    Worth surfacing rather than quietly settling - unbounded growth in how
+    much code you took on is a signal, but probably not a good one. It is the
+    lines-of-code metric with a smaller coefficient, and the one-sided guard
+    around it is all that stops it penalising a citizen who deletes code. It
+    survives because PRD section 8 forbids removing a signal mid-cohort, not
+    because it earned its place. Revisit between cohorts.
+    """
+    return deltas.functions if config.complexity_growth_reads_functions else deltas.complexity
+
+
 def composite_score(
     deltas: MetricDeltas,
     iterations: int,
@@ -164,11 +186,12 @@ def composite_score(
     if iterations > 0:
         score += math.log2(iterations + 1) * weights.iteration_count * iterations
 
-    # Complexity only ever adds. Growing it alongside tests is healthy growth;
-    # growing it without tests earns a smaller credit, not a penalty.
-    if deltas.complexity > 0:
+    # Only ever adds. Growing alongside tests is healthy; growing without
+    # tests earns a smaller credit, never a penalty.
+    growth = _growth_delta(deltas, config)
+    if growth > 0:
         factor = 1.0 if deltas.test_count > 0 else config.untested_complexity_factor
-        score += deltas.complexity * weights.complexity_growth * factor
+        score += growth * weights.complexity_growth * factor
 
     score += deltas.docstrings * weights.documentation_delta
 
@@ -264,10 +287,17 @@ def _lint_note(deltas: MetricDeltas) -> Note:
     return ([], [])
 
 
-def _complexity_note(deltas: MetricDeltas) -> Note:
-    if deltas.complexity > 0 and deltas.test_count > 0:
+def _complexity_note(deltas: MetricDeltas, config: VelocityConfig) -> Note:
+    """Keyed on the same delta the score term is, for the same reason.
+
+    These sentences say "you took on more code", which is what a `def ` count
+    measures. Said about a C901 count they would congratulate a citizen for
+    writing a function with more branches than the threshold allows.
+    """
+    growth = _growth_delta(deltas, config)
+    if growth > 0 and deltas.test_count > 0:
         return (["Complexity growth backed by tests. Sustainable expansion."], [])
-    if deltas.complexity > 5 and deltas.test_count == 0:
+    if growth > 5 and deltas.test_count == 0:
         return ([], [
             "Complexity grew significantly. Consider adding tests to validate new logic."
         ])
@@ -295,7 +325,7 @@ def analyze_growth(
         _tests_note(deltas),
         _documentation_note(deltas, current),
         _lint_note(deltas),
-        _complexity_note(deltas),
+        _complexity_note(deltas, config),
     ]
 
     celebrations = [line for note in notes for line in note[0]]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 
 import json
 
-from shodann.analysis import AnalysisReports, read_coverage, read_lint_issues
+from shodann.analysis import (
+    AnalysisReports,
+    read_complexity,
+    read_coverage,
+    read_lint_issues,
+)
 from shodann.review import collect_metrics
 
 
@@ -106,3 +111,60 @@ def test_a_coverage_gain_now_moves_the_velocity_score(tmp_path) -> None:
 
     assert calculate_velocity(current, previous, 1).score > 0
     assert calculate_velocity(current, previous, 1).deltas.coverage == 25.0
+
+
+# --- complexity, the metric the pin was protecting but nobody computed -----
+
+
+def diagnostic(code: str) -> dict:
+    """One ruff diagnostic, trimmed to the fields anything here reads."""
+    return {"code": code, "message": f"{code} happened", "filename": "x.py"}
+
+
+def test_complexity_counts_only_the_branch_rule(tmp_path) -> None:
+    path = write(
+        tmp_path / "ruff.json",
+        [diagnostic("C901"), diagnostic("E501"), diagnostic("C901"), diagnostic("F401")],
+    )
+    assert read_complexity(path) == 2
+    assert read_lint_issues(path) == 4, "the lint term still counts every diagnostic"
+
+
+def test_a_clean_report_is_a_measured_zero(tmp_path) -> None:
+    """No function over the threshold is the answer, not the absence of one."""
+    path = write(tmp_path / "ruff.json", [])
+    assert read_complexity(path) == 0
+
+
+def test_an_absent_report_is_not_a_clean_codebase(tmp_path) -> None:
+    assert read_complexity(tmp_path / "nope.json") is None
+    assert AnalysisReports.from_directory(tmp_path).complexity is None
+
+
+def test_a_truncated_lint_report_degrades_rather_than_raising(tmp_path) -> None:
+    path = tmp_path / "ruff.json"
+    path.write_text('[{"code": "C90', encoding="utf-8")
+    assert read_complexity(path) is None
+
+
+def test_the_wrapped_diagnostics_shape_is_read_too(tmp_path) -> None:
+    """Some ruff versions wrap the list in an object; read_lint_issues handles both."""
+    path = write(tmp_path / "ruff.json", {"diagnostics": [diagnostic("C901")]})
+    assert read_complexity(path) == 1
+    assert read_lint_issues(path) == 1
+
+
+def test_complexity_reaches_the_metrics_from_the_report(tmp_path) -> None:
+    """It used to be a count of `def `, which is what `functions` already was."""
+    (tmp_path / "thing.py").write_text(
+        "def one():\n    return 1\n\n\ndef two():\n    return 2\n", encoding="utf-8"
+    )
+    write(tmp_path / "ruff.json", [diagnostic("C901"), diagnostic("E501")])
+
+    metrics = collect_metrics(tmp_path, AnalysisReports.from_directory(tmp_path))
+
+    assert metrics.complexity == 1, "one function over the branch threshold"
+    assert metrics.functions == 2, "two functions defined"
+    assert metrics.complexity != metrics.functions, (
+        "these were the same number for as long as nothing measured C901"
+    )

--- a/tests/test_velocity_contracts.py
+++ b/tests/test_velocity_contracts.py
@@ -16,6 +16,7 @@ from shodann.velocity import (
     FIRST_TESTS_PHRASE,
     CodeMetrics,
     MetricDeltas,
+    _coverage_multiplier,
     calculate_velocity,
     composite_score,
 )
@@ -108,6 +109,50 @@ def test_the_retired_engine_really_did_score_them_the_same() -> None:
         metrics(coverage=80.0, **base), metrics(coverage=50.0, **base), 1, config=ORACLE_CONFIG
     )
     assert first.score == later.score == pytest.approx(60.50)
+
+
+def test_the_first_test_bonus_keeps_its_magnitude_not_just_its_sign() -> None:
+    """The direction of US-1.3 is cheap to satisfy. The strength is the promise.
+
+    `test_first_coverage_gain_outscores_an_equal_later_gain` above asserts only
+    `first.score > later.score`, and that ordering survives almost any positive
+    bonus: at `first_test_bonus = 0.05` the multipliers are 1.05 and 1.025, so
+    the comparison still passes while the pedagogy is gone. A surveyor moved
+    the constant 1.0 -> 0.05 and all 247 tests stayed green.
+
+    So pin the constant and the curve it produces. `first_test_bonus` is a
+    *score input*, and PRD section 8 freezes those for cohort 1: changing this
+    number after the first real submission invalidates every citizen's
+    baseline. A deliberate change means changing this test, which is the point.
+    """
+    assert DEFAULT_CONFIG.first_test_bonus == 1.0
+
+    # 1 + bonus * headroom, so a citizen at zero coverage earns double and a
+    # citizen at full coverage earns single. Nothing in between is special.
+    assert _coverage_multiplier(0.0, DEFAULT_CONFIG) == 2.0
+    assert _coverage_multiplier(50.0, DEFAULT_CONFIG) == 1.5
+    assert _coverage_multiplier(100.0, DEFAULT_CONFIG) == 1.0
+
+    # Out of range readings saturate rather than inverting the curve.
+    assert _coverage_multiplier(-10.0, DEFAULT_CONFIG) == 2.0
+    assert _coverage_multiplier(140.0, DEFAULT_CONFIG) == 1.0
+
+
+def test_the_bonus_is_worth_a_stated_number_of_points() -> None:
+    """The same coverage gain, from two bases, differing by a known amount.
+
+    Guards the magnitude end to end rather than in the multiplier alone: an
+    identical delta of 10 points scores `10 * 2.0 * (2.0 - 1.5)` = 10 higher
+    when it starts from zero. Under a flattened bonus of 0.05 the gap is 0.5.
+    """
+    base = dict(test_count=4, complexity=10, loc=200, functions=8, docstrings=3, lint_issues=2)
+    from_zero = calculate_velocity(
+        metrics(coverage=10.0, **base), metrics(coverage=0.0, **base), 1
+    )
+    from_fifty = calculate_velocity(
+        metrics(coverage=60.0, **base), metrics(coverage=50.0, **base), 1
+    )
+    assert from_zero.score - from_fifty.score == pytest.approx(10.0)
 
 
 def test_first_test_emits_the_required_phrase() -> None:

--- a/tests/test_velocity_contracts.py
+++ b/tests/test_velocity_contracts.py
@@ -155,6 +155,46 @@ def test_the_bonus_is_worth_a_stated_number_of_points() -> None:
     assert from_zero.score - from_fifty.score == pytest.approx(10.0)
 
 
+# --- the growth term reads what it means ----------------------------------
+
+
+def test_the_growth_term_reads_functions_not_complexity() -> None:
+    """`complexity` now carries a C901 count, and this term must not read it.
+
+    A positive delta in a C901 count means the citizen added a function over
+    the branch threshold. Scored through `weights.complexity_growth` that
+    would pay them for it - a punitive signal inverted into a reward, which is
+    worse than the mislabel it replaced.
+
+    `functions` is what the term always meant: how much code you took on.
+    Until C901 was measured the two fields held the same `def ` count, so no
+    real citizen's score moves by any amount.
+    """
+    base = dict(coverage=50.0, test_count=4, loc=200, docstrings=3, lint_issues=2)
+    # Took on four more functions while cleaning every one over the threshold.
+    previous = metrics(complexity=6, functions=8, **base)
+    current = metrics(complexity=0, functions=12, **base)
+
+    result = calculate_velocity(current, previous, 1)
+
+    assert result.deltas.functions == 4
+    assert result.deltas.complexity == -6
+    # Credited for the four, and the guard keeps the -6 from ever subtracting.
+    assert result.score > calculate_velocity(previous, previous, 1).score
+
+
+def test_the_oracle_still_reads_complexity() -> None:
+    """The divergence is expressed as config, so the snapshot stays byte-exact.
+
+    `design_docs/growth-velocity.js` scored `complexity`, and the fixtures are
+    captured evidence from it - the only place the two fields ever differ. If
+    this flips, `tests/test_oracle_snapshot.py` fails for a reason that has
+    nothing to do with a transcription error, which is what it exists to find.
+    """
+    assert DEFAULT_CONFIG.complexity_growth_reads_functions is True
+    assert ORACLE_CONFIG.complexity_growth_reads_functions is False
+
+
 def test_first_test_emits_the_required_phrase() -> None:
     result = calculate_velocity(metrics(coverage=12.0, test_count=1), None, 1)
     assert any(FIRST_TESTS_PHRASE in line for line in result.celebrations)

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -100,6 +100,44 @@ def test_the_citizen_does_not_choose_which_lint_rules_count(workflow: str) -> No
     assert "--isolated" in style, "rule selection is a score input, not a preference"
 
 
+def test_isolating_ruff_does_not_also_discard_the_complexity_rule(workflow: str) -> None:
+    """--isolated throws away our configuration along with the citizen's.
+
+    C901 is not in ruff's default set: run it isolated against a function with
+    twelve branches and it reports nothing. So the complexity metric PRD
+    section 8 names was unreachable from the moment --isolated shipped,
+    whatever this repository's `select` said - and `pyproject.toml` claimed
+    the ruff pin was protecting a baseline that nothing computed.
+    """
+    style = workflow.split("Style and complexity")[1].split("- name:")[0]
+    run = "\n".join(
+        line for line in style.splitlines() if line.strip() and not line.strip().startswith("#")
+    )
+
+    assert "C90" in run, "C901 is the complexity metric; without it nothing is measured"
+    assert "max-complexity" in run, "the threshold decides what counts as a violation"
+
+
+def test_the_complexity_rule_is_added_without_replacing_the_lint_set(workflow: str) -> None:
+    """--extend-select, never a bare --select, and the distinction is a rescore.
+
+    `lint_issues` is a frozen score input feeding the sqrt term. Replacing
+    ruff's default selection rather than extending it moves that count: on
+    this repository an explicit `E4,E7,E9,F,C90` took it from 19 to 0, and the
+    full house rule set took it to 492 - mostly S101, one per assert, so every
+    citizen who wrote a test would have watched their lint reading get worse.
+
+    Adding a signal is permitted mid-cohort. Changing one is not.
+    """
+    style = workflow.split("Style and complexity")[1].split("- name:")[0]
+    run = "\n".join(
+        line for line in style.splitlines() if line.strip() and not line.strip().startswith("#")
+    )
+
+    assert "--extend-select" in run, "extending adds C901; selecting would rewrite the lint term"
+    assert "--select " not in run, "a bare --select silently rescores every citizen's lint delta"
+
+
 def test_every_score_feeding_tool_is_pinned_exactly(workflow: str) -> None:
     """An open version bound on a measurement tool is an unannounced rescore.
 

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -12,6 +12,7 @@ between a green CI run and a wrong number.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -97,6 +98,45 @@ def test_the_citizen_does_not_choose_which_lint_rules_count(workflow: str) -> No
 
     assert "ruff check" in style
     assert "--isolated" in style, "rule selection is a score input, not a preference"
+
+
+def test_every_score_feeding_tool_is_pinned_exactly(workflow: str) -> None:
+    """An open version bound on a measurement tool is an unannounced rescore.
+
+    The freeze in PRD section 8 is about the numbers, not the source: a
+    coverage.py release that changes how partial branches are counted moves
+    every citizen's heaviest input with nothing in the diff to show for it.
+    ruff carried an exact pin from the start; pytest-cov, which produces the
+    2.0-weighted term, ran open beside it.
+
+    pytest is deliberately absent from this list. Test count is counted from
+    source in `collect_metrics`, never from a run, so no pytest release can
+    move it.
+    """
+    step = workflow.split("Install the frozen toolchain")[1].split("- name:")[0]
+    run = "\n".join(
+        line for line in step.splitlines() if line.strip() and not line.strip().startswith("#")
+    )
+
+    for tool in ("ruff", "pytest-cov"):
+        assert re.search(rf'"{re.escape(tool)}==[0-9]', run), (
+            f"{tool} output reaches the velocity score and must carry an exact pin"
+        )
+
+
+def test_the_pinned_versions_match_the_project_metadata(workflow: str) -> None:
+    """Two files install the measurement set; they must agree on which one.
+
+    The workflow measures the citizen and `pyproject.toml` builds the
+    maintainer's environment. A drift between them means a defect reproduces
+    on one and not the other, which is the slowest possible way to find it.
+    """
+    extras = (WORKFLOW.parent.parent.parent / "pyproject.toml").read_text(encoding="utf-8")
+    for tool in ("ruff", "pytest-cov"):
+        in_workflow = re.search(rf'"{re.escape(tool)}==([0-9][^"]*)"', workflow)
+        in_project = re.search(rf'"{re.escape(tool)}==([0-9][^"]*)"', extras)
+        assert in_workflow and in_project, f"{tool} must be pinned in both files"
+        assert in_workflow.group(1) == in_project.group(1), f"{tool} pins disagree"
 
 
 def test_no_citizen_text_is_interpolated_into_a_shell(workflow: str) -> None:


### PR DESCRIPTION
## Changes Summary

Three defects in what SHODANN *measures*. PRD §8 freezes the measurement set for cohort 1, so each of these is free to fix today and impossible after the first real submission — fixing one later invalidates every citizen's history. Sorted by that clock, not by size.

**Stacked on #56.** Its base is `claude/plan-first-issue-u1nx38`, because rung 2 changes score inputs and the six-cell CI matrix that verifies them only exists in #56. GitHub will retarget this to `main` when #56 merges.

### 1. The first-test bonus was pinned by sign, not by magnitude

US-1.3's contract test asserts only that a gain from zero outscores an equal gain from fifty. That ordering survives almost any positive bonus — at `first_test_bonus = 0.05` the multipliers are 1.05 and 1.025, the comparison still passes, and the pedagogy is gone. A surveyor moved the constant 1.0 → 0.05 and all 247 tests stayed green.

Now pinned at both ends: the multiplier at 0/50/100 and outside the range where it must saturate rather than invert, plus the end-to-end magnitude — an identical 10-point gain scores exactly 10 higher from a zero base. Both fail against 0.05; the pre-existing directional test still passes, which is the gap being closed.

### 2. `pytest-cov` ran unpinned beside an exactly pinned ruff

Coverage is the 2.0-weighted term, the largest in the composite. `pytest-cov` was open in the workflow and absent from the dev extras entirely, so the maintainer's environment and the runner's could disagree silently. A coverage.py release that changes how partial branches are counted moves every citizen's heaviest input with nothing in the diff to show for it — which is the exact failure mode the ruff pin exists to prevent, applied to the lighter input and not the heavier one.

Pinned to `7.1.0` in both places, with a contract test that every score-feeding tool carries an `==` pin and that the two files agree on the version. `pytest` itself stays open: test count is counted from source, never from a run.

### 3. The number labelled "complexity" was a count of the word `def`

`collect_metrics` set `complexity = functions`, both from one variable. The live ledger shows it plainly: `complexity: 311, functions: 311`. So `pyproject.toml`'s claim that the ruff pin protected a complexity baseline was false in both halves — nothing read a `C901` diagnostic, and nothing *could*.

Nothing could because `--isolated` (shipped last sprint) discards our configuration along with the citizen's, and **`C901` is not in ruff's default set** — run it isolated against a function with twelve branches and it reports nothing at all. Verified directly, not inferred. The complexity metric PRD §8 names has been unreachable since `--isolated` landed.

## Two decisions inside #3 worth reviewing on their own

**`--extend-select C90`, never a bare `--select`.** `lint_issues` is a frozen score input feeding the sqrt term, and *replacing* ruff's default selection rather than extending it moves that count. Measured on this repository: an explicit `E4,E7,E9,F,C90` took it from 19 to **0**, and the full house rule set took it to **492** — mostly `S101`, one per assert, so every citizen who wrote a test would have watched their lint reading get worse. Extending leaves all 19 untouched and adds exactly one rule. Adding a signal is permitted mid-cohort; changing one is not.

**The score does not read the new number, and that is a decision rather than an omission.** A positive delta in a `C901` count means the citizen *added a function over the branch threshold*, and `weights.complexity_growth` would have paid them for it — a punitive signal inverted into a reward, worse than the mislabel it replaced. The growth term now reads `functions`, which is what it always meant: how much code did you take on. **Every real citizen's score is unchanged**, because the two fields held the same number for every reading ever taken.

They differ only in the oracle fixtures — captured evidence from the retired JavaScript engine, which must not be re-cut to make a test pass. So the divergence is expressed as config (`complexity_growth_reads_functions`, false in `ORACLE_CONFIG`), the same mechanism `first_test_bonus` already uses. `tests/fixtures/oracle_snapshot.json` is **untouched** and the snapshot stays byte-exact.

The rationale is recorded in `velocity._growth_delta`, not only here, because it is what a later reader needs at the moment they consider changing it: unbounded growth in how much code you took on is a signal, but probably not a good one. It is the lines-of-code metric with a smaller coefficient, and the one-sided guard is all that stops it penalising a citizen who deletes code. It survives because the freeze forbids removing a signal mid-cohort, not because it earned its place. Revisit between cohorts.

## Related Issues

None, deliberately — the survey items live in `design_docs/sprints/2026-07-28/01-candidates.md`, which is the live backlog. Addresses **S1-03**, **S1-04** and **S1-05** from it.

## Component(s) Affected

- [x] Core Workflow (GitHub Actions)
- [x] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [ ] Persona/Voice System
- [ ] State Management
- [ ] Templates
- [ ] Documentation
- [x] Other: hard-analysis report readers (`src/shodann/analysis.py`)

## Testing Performed

- [x] Manual testing completed
- [x] Tested with sample data/workflows
- [x] Reviewed output/behavior
- [x] Edge cases considered

**Testing Details:**

**269 passed, 3 skipped**, ruff clean (259 before this PR, 249 before #56).

Every new guard was verified to fail against the defect it describes, not just to pass:

| Guard | Reverted to | Result |
|---|---|---|
| first-test bonus magnitude | `first_test_bonus = 0.05` | 2 failed, 23 passed |
| score-feeding tools pinned | `pytest-cov` unpinned | 2 failed, 8 passed |
| complexity rule reachable | `--extend-select` removed | 1 failed, 10 passed |

Measured behaviour, not asserted:

- `ruff --isolated` against a 12-branch function → `codes: []`. With `--extend-select C90` → `codes: ['C901']`. This is the evidence that the rule was unreachable.
- `--extend-select C90` on this repo → total stays **19**, `C901: 0`. The lint signal is provably undisturbed.
- End to end with a `C901`-bearing report: `reports.complexity = 2`, `metrics.complexity = 2`, `metrics.functions = 361`, and the prompt's Complexity row reads **0 → 2 (+2)** where it previously read 361.
- A clean `ruff.json` reads `0` (a real answer — no function over the threshold); an absent one reads `None` and never 0.
- `tests/fixtures/oracle_snapshot.json` unchanged; all 8 oracle cases still match byte-exact.

## Documentation Updated

- [x] Code comments added/updated
- [ ] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated
- [ ] No documentation changes needed

**Files Updated:** `pyproject.toml` (the false claim about what the ruff pin protected), `src/shodann/config.py`, `src/shodann/velocity.py`, `src/shodann/analysis.py`, `.github/workflows/shodann.yml` — all inline, at the places a maintainer would stand when changing them.

## Educational Impact Assessment

### Student-Facing Changes

**Yes, one.** The Complexity row in a review now reports how many of the citizen's functions exceed the branch threshold, instead of how many functions they have. For most submissions that number is 0 — true, and better news than the figure it replaces.

No citizen's velocity score changes by any amount. No stored baseline shifts. The ledger's existing `complexity` values are `def` counts and the next reading will be a `C901` count, so a one-time discontinuity appears in the author's own record — noted in `01-candidates.md` alongside S1-16/17, which is where the ledger's other contamination is already tracked.

### Pedagogical Alignment

- [x] Maintains growth-positive framing
- [x] Appropriate for target clearance level(s)
- [x] Preserves SHODANN persona/voice consistency
- [x] Supports velocity-over-position principle
- [x] No negative impact on learning experience
- [ ] Not student-facing

The clearest pedagogical gain is negative-space: declining to score `C901` keeps SHODANN from congratulating a citizen for writing a function too complex to follow.

### Clearance Levels Affected

- [ ] INFRARED (Complete beginner)
- [ ] RED (Junior)
- [ ] ORANGE (Mid-level)
- [ ] YELLOW (Senior)
- [ ] GREEN (Lead)
- [ ] BLUE+ (Strategic)
- [x] All levels
- [ ] Not student-facing

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed — n/a
- [x] Persona voice maintained (if student-facing content)
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above — explicitly none, with reasoning
- [x] Educational impact assessed above

## Additional Notes

The frozen plan for this rung said `complexity` should become the C901 count *and* stay the score input, with a migration guard for the unit change. Reading the engine showed `MetricDeltas` already carried `complexity` and `functions` as separate fields with the score using only the former — which opened the route that rescores nobody. That was raised as a decision rather than applied quietly, and the report-only option was chosen deliberately.

Two things this PR does **not** do, both still open in `01-candidates.md`: the DATA layer is still fed hardcoded zeros for syntax errors and test tallies (S1-06/07/08), and clearance is still permanently RED for every citizen (S1-09).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MDFNeETL6SFPY2PYfwyBiK)_