### PR TITLE
Teach CLAUDE.md the two skills it now has, and their opposite rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `src/shodann/` — the implementation. Velocity engine, prompt assembly, output validator, groundedness probe, clearance calibration, capability declaration, citizen ledger.
 - `.github/workflows/shodann.yml` — live, two jobs, posts a comment on every PR to this repo.
-- `tests/` — 467 tests, including golden tests against the JS oracle, contract tests that read the workflow YAML as text, and groundedness probes that read the assembled output. One test is skipped on purpose (`reduced_allocation` is not synthesised); any other skip is a bug — see the guard rule in Landmines.
-- `design_docs/sprints/2026-07-28/` — one sprint, documented end to end: `01-candidates.md` (the live backlog — 37 surveyed items plus nine filed since, and a Closure section that is the only place recording which are done), `02-prediction.md`, `03-treatment.md`, `04-retro.md`, `05-assay.md`.
-- `.claude/skills/the-algorithm/` — a vendored discipline, pinned by commit. **Never edited here.** See `design_docs/addenda/the-algorithm.md`.
+- `tests/` — 474 tests, including golden tests against the JS oracle, contract tests that read the workflow YAML as text, and groundedness probes that read the assembled output. One test is skipped on purpose (`reduced_allocation` is not synthesised); any other skip is a bug — see the guard rule in Landmines.
+- `design_docs/sprints/2026-07-28/` — one sprint, documented end to end: `01-candidates.md` (the live backlog — 37 surveyed items plus ten filed since, and a Closure section that is the only place recording which are done), `02-prediction.md`, `03-treatment.md`, `04-retro.md`, `05-assay.md`.
+- `.claude/skills/the-algorithm/` — a vendored discipline, pinned by commit in `PROVENANCE.md`. **Never edited here**; amend upstream, through its own gate, then re-vendor. See `design_docs/addenda/the-algorithm.md`.
+- `.claude/skills/shodann-voice/` and `.claude/agents/shodann.md` — the persona and the register, **governed by the opposite rule to the skill above**. They are a *shared base*, byte-identical to the copies in `norrisaftcc/the_intern` and stamped `2026-07-31.1`; the two repositories are **expected to diverge**. Editing them here is allowed and anticipated — say which base version the change started from, because the stamp is what a divergence is measured against. Neither copy is the other's upstream, so never re-vendor one over the other.
 - `design_docs/growth-velocity.js` — the **reference oracle**, not the runtime. Kept so the port stays checkable. Do not extend it.
 - `design_docs/shodann-core.yml` — the historical 5-job draft. Never deployed, unsafe as written (see Landmines 1). Read it for the literal tool invocations; do not copy it.
 
@@ -34,6 +35,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 They disagree constantly (see Landmines). `design_docs/README.md` sets the last rule itself: files directly in `design_docs/` are current; anything under `shodann-architecture-prototype/` is historical, corroborating only. Prose restatements of the velocity formula in `PRD.md` and `SHODANN_CLAUDE.md` are all partial.
 
 Since the port, **`src/shodann/` outranks everything**, including `growth-velocity.js`. The JS is the oracle the Python is *checked against*, not the source of truth about current behaviour — the two have deliberately diverged where the JS was wrong (Landmine 5) and where PRD invariants demanded it.
+
+The same rule settles the newest pair. `.claude/agents/shodann.md` and `.claude/skills/shodann-voice/SKILL.md` read like sources and are not: they are *derived* from `design_docs/SHODANN_VOICE_GUIDE.md` (modes, vocabulary table, never-says list) and `src/shodann/clearance.py` (the teaches → mentors → reports ladder, quoted there in condensed form). Where a condensation disagrees with the code, **the code wins** and the condensation is the defect.
 
 ### Language: Python (decided 2026-07-25)
 
@@ -151,7 +154,7 @@ Edge-case detection (`05_edge_case_handlers.md`): `EMPTY_PR` = `files_changed ==
 
 ## Output contract and voice
 
-These rules govern **generated PR-comment output only** — not your replies to the user, commit messages, or issue text. Do not speak in the SHODANN persona while working on the repo.
+These rules govern **generated PR-comment output only** — not your replies to the user, commit messages, or issue text. Do not speak in the SHODANN persona while working on the repo — with one exception, the `shodann` agent seat (`.claude/agents/shodann.md`), which is the persona made dispatchable. It holds no `Write` or `Edit` tool, so "nothing is written" is a fact about its tool list rather than a promise in its prose; keep it that way.
 
 Standard path, exact headings in order:
 
@@ -201,7 +204,7 @@ These were written against the specs, before the port. **3, 5, 6, 7 and 9 are re
 
 Four more, learned from running it:
 
-- **A green suite proves very little here.** Twenty-five defects in `EARLY_RUNS.md`, all found by running the system, all with the suite passing — including three that were contracts *between the workflow YAML and the program*, which no test could see until `tests/test_workflow_contract.py` started reading the YAML as text. **Revert every new guard against the defect it was written for before believing it.** Nine probes were run that way on 2026-07-29 and one guard had been green since birth against nothing. Reverting is necessary and not sufficient: a guard **scoped to the thing you changed** passes its own revert and still misses the defect. Entry 18 took three attempts because two guards asserted on the prompt row that had already been fixed, while the figure was arriving from `describe_history` all along. Assert on the assembled output, not on your edit. And a guard that never runs is worse than one scoped too narrowly: entry 25 found a test parametrised over three files that skipped all three for its whole life, so `sss` read as a pass. **Check that a new test executes at all** - a skip and a pass are one character apart in a summary line.
+- **A green suite proves very little here.** Twenty-five defects in `EARLY_RUNS.md`, all found by running the system, all with the suite passing — including three that were contracts *between the workflow YAML and the program*, which no test could see until `tests/test_workflow_contract.py` started reading the YAML as text. **Revert every new guard against the defect it was written for before believing it.** Nine probes were run that way on 2026-07-29 and one guard had been green since birth against nothing. Reverting is necessary and not sufficient: a guard **scoped to the thing you changed** passes its own revert and still misses the defect. Entry 18 took three attempts because two guards asserted on the prompt row that had already been fixed, while the figure was arriving from `describe_history` all along. Assert on the assembled output, not on your edit. And a guard that never runs is worse than one scoped too narrowly: entry 25 found a test parametrised over three files that skipped all three for its whole life, so `sss` read as a pass. **Check that a new test executes at all** - a skip and a pass are one character apart in a summary line. That YAML-as-text family now covers `.claude/` markdown too (`tests/test_shodann_persona.py`, `tests/test_agent_retargeting.py`), and **they pin the persona, not the prose** — movement-not-position, the twice-changing ladder, the 400-word cap, the absent `Write` tool, the never-says list. Pinning the text would fight the divergence those files are designed for and break on the first legitimate edit; do not "tighten" them into a byte-comparison.
 - **A loop is evidence that a boundary is wrong.** The floor is Audience, Scope, Format, Path (`design_docs/addenda/the-algorithm.md`); an unterminating loop implicates one or more and *always* implicates **Scope**, because the other three produce one wrong artifact while only a wrong boundary produces another pass. Four for four on PR #61 (entry 25). So count the passes: three attempts at one defect is not persistence, it is a scope you have not restated. And measure the rate, not just the count - **commit interval below time-to-observe-consequence** means you are landing changes on top of unobserved change, which is the one condition the suite cannot see because the suite stays green throughout it.
 - **Anything feeding the score must not be choosable by the citizen being scored.** `--cov=.` counted a student's own test files in the coverage denominator, and `ruff check` without `--isolated` let their `pyproject.toml` decide which rules were counted. Both were live; both are now asserted in `tests/test_workflow_contract.py`. **The third instance was a file, not a flag**: nothing deleted the report files first, so a citizen could commit a `coverage.json` claiming 97% and break their own test collection to make it survive (`EARLY_RUNS.md` 12). Reading the flags again would never have found it. This is the lines-of-code metric in a new unit — check any new signal against it before adding one, and ask what the citizen could *put in the checkout*, not only what they could configure.
 - **The freeze is a deadline, not a preference.** `PRD.md` §8 freezes the measurement set for cohort 1, so a defect in a *measurement* is free to fix today and impossible after the first real submission — fixing it later invalidates every student's history. Adding a signal stays legal mid-cohort; changing or removing one does not. Sort measurement work by that clock, not by value.
@@ -224,7 +227,7 @@ Four more, learned from running it:
 | Question | File |
 |---|---|
 | **What broke when it ran, and why** | `design_docs/EARLY_RUNS.md` |
-| **The live backlog — 46 items, and which are closed** | `design_docs/sprints/2026-07-28/01-candidates.md` |
+| **The live backlog — 47 items, and which are closed** | `design_docs/sprints/2026-07-28/01-candidates.md` |
 | How this repo negotiates, and the floor test | `design_docs/addenda/the-algorithm.md` |
 | Why correct changes still compound into a problem | `design_docs/addenda/accumulation.md` |
 | What a second repository would need to subscribe (it cannot today) | `design_docs/ONBOARDING_A_REPOSITORY.md` |
@@ -237,7 +240,9 @@ Four more, learned from running it:
 | What a model may not say about a number it was given | `src/shodann/groundedness.py` |
 | Clearance postures (teaches → mentors → reports) | `design_docs/CLEARANCE_REGISTER.md` |
 | Leaderboard partition: human vs agent, ORANGE gate | `design_docs/LEADERBOARD.md` |
-| The agent fleet, its three epistemic positions | `.claude/agents/README.md` |
+| The agent fleet: five maintained agents, three epistemic positions, what each was exercised on, and the retargeting order for the inherited ones — an agent is done when it has produced a usable result on live work here, not when its prompt reads well | `.claude/agents/README.md` |
+| The register without the seat — modes, the ladder, the divergence rule and its version stamp | `.claude/skills/shodann-voice/SKILL.md` |
+| Season one as the engine measured it, frozen and never updated | `design_docs/pilot/README.md` |
 | Scope, out-of-scope, Gherkin acceptance criteria, error handling | `PRD.md` |
 | Pipeline rationale, hard/soft split, integration points | `design_docs/SHODANN_CLAUDE.md` |
 | Voice: vocabulary, forbidden phrases, emoji sets, clearance buckets | `design_docs/SHODANN_VOICE_GUIDE.md` |


### PR DESCRIPTION
## Changes Summary

Brings `CLAUDE.md` up to the repository's current state. Its last content update was #61; #65 (the SHODANN persona base and the `shodann-voice` skill) and #64 (retargeting the linx voice agent) landed after it, and the file knew about neither.

The stale counts were the smaller half. The real problem: `.claude/skills/` now holds **two skills governed opposite ways**, and `CLAUDE.md` documented only one. A fresh session read "a vendored discipline, pinned by commit, **never edited here**" and had no way to learn that `shodann-voice` is a *shared base designed to diverge*, stamped `2026-07-31.1` so a divergence can be measured against something. The same session read "do not speak in the SHODANN persona while working on the repo" with no way to learn that a dispatchable `shodann` seat now exists that is supposed to.

Both questions are now answerable from `CLAUDE.md` alone. Six targeted edits:

1. **Counts** — 467 → 474 tests; backlog "nine filed since" → ten, "46 items" → 47. Both re-derived from the tree, not copied from a plan.
2. **The `.claude/` bullet** — both skills, and the rule separating them stated as a contrast, since the trap is that they look alike.
3. **Persona seat carve-out** — the `shodann` agent holds no `Write`/`Edit` tool, so "nothing is written" is a fact about its tool list rather than a promise in its prose.
4. **Source precedence** — `shodann.md` and `shodann-voice/SKILL.md` read like sources and are not; they are derived from `SHODANN_VOICE_GUIDE.md` and `clearance.py`. Existing precedence therefore already settles a disagreement: the code wins, and the condensation is the defect.
5. **Green-suite landmine** — the contract-tests-read-a-non-code-file family now covers `.claude/` markdown. Records *why* those tests pin the persona rather than the prose, so a later session does not "tighten" them into a byte-comparison and break the divergence they exist to allow.
6. **`Where to look`** — rows for `shodann-voice/SKILL.md` and `design_docs/pilot/` (previously unmentioned anywhere: `grep -c pilot CLAUDE.md` returned 0), plus the fleet row updated to five maintained agents and the retargeting rule.

Deliberately **not** a rewrite. The landmines, the `EARLY_RUNS.md` summaries, the toolchain freeze and the velocity math were current and are untouched — an assay found 161 of 190 sentences load-bearing, and rewriting would discard content no fresh reading of the code could reconstruct. `S1-47` is counted but not narrated: it is an instance of a rule the file already states, and the file has no slack to spend.

## Related Issues

None. This is documentation drift found by reading the tree against the file, not a filed item.

## Component(s) Affected

- [x] Documentation
- [ ] Core Workflow (GitHub Actions)
- [ ] Velocity Calculation Engine
- [ ] RAGE STATE (Security Mode)
- [ ] Persona/Voice System
- [ ] State Management
- [ ] Templates

Persona/Voice is left unticked on purpose: this **describes** the persona files, and changes none of them.

## Testing Performed

- [x] Manual testing completed
- [x] Reviewed output/behavior
- [x] Edge cases considered
- [ ] Tested with sample data/workflows

**Testing Details:**

- `python scripts/dev.py all` → **473 passed, 1 skipped**, `ruff check .` clean. The skip is the intended `reduced_allocation is not synthesised` at `tests/test_clearance.py:78`; no new skips.
- The six `.claude/` contract tests were run with `-v` to confirm they **execute** rather than skip — a skip and a pass are one character apart in a summary line, and entry 25 of `EARLY_RUNS.md` is that exact defect.
- **Every path named in the file was stat'd.** Landmine 10 is this defect class, and so was the venv path that broke every non-Windows session for months. Diffed the unresolved set before vs. after: this change introduces exactly one bare filename, `PROVENANCE.md`, cited in the same sentence as its directory — the convention the file already uses for `01-candidates.md`.
- Both counts re-derived independently rather than trusted: `grep -oE '^\| S1-[0-9]+' … | sort -u | wc -l` → 47, ten of them post-survey.
- Diff read end to end against the two questions the change exists to answer: may I edit `shodann-voice/SKILL.md`, and may I write in the persona?

## Documentation Updated

- [x] Code comments added/updated — n/a
- [ ] Design docs updated
- [ ] README updated
- [ ] User-facing documentation updated

**Files Updated:** `CLAUDE.md` only (+12 / −7).

## Educational Impact Assessment

### Student-Facing Changes

None. `CLAUDE.md` is maintainer-facing guidance. No prompt, template, validator rule, or velocity input is touched, so no citizen sees a different comment as a result of this PR.

### Pedagogical Alignment

- [x] Not student-facing
- [ ] Maintains growth-positive framing
- [ ] Appropriate for target clearance level(s)
- [ ] Preserves SHODANN persona/voice consistency
- [ ] Supports velocity-over-position principle
- [ ] No negative impact on learning experience

### Clearance Levels Affected

- [x] Not student-facing

## Pre-Merge Checklist

- [x] Code follows project style and conventions
- [x] Comments added for complex logic — n/a
- [x] Documentation updated (if needed)
- [x] Design docs updated if architecture changed — no architecture change
- [x] Persona voice maintained (if student-facing content) — not student-facing; the repo rule against writing in-persona outside generated output is followed here
- [x] No hardcoded credentials or sensitive data
- [x] Testing completed successfully
- [x] Related issues linked above — none apply
- [x] Educational impact assessed above

## Additional Notes

The `Where to look` row for the agent fleet is long. It is carrying a rule worth reading before retargeting an inherited agent — that an agent is done when it has produced a usable result on live work in this repository, not when its prompt reads well — and I would rather it be long than the rule live only in a file nobody is told to open. Trim it if you disagree.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165zms7FBfPatsc3gakbKyV)_