### PR TITLE
Vendor the lite skill, and take the edition that actually saves tokens

### DIFF
--- a/.claude/skills/the-algorithm/HOUSE-STYLE.md
+++ b/.claude/skills/the-algorithm/HOUSE-STYLE.md
@@ -1,17 +1,103 @@
-# HOUSE-STYLE (DRAFT — pending amendment)
+# HOUSE-STYLE v2.0 — public edition
 
-Status: draft. The Language lock in `SKILL.md` currently references ASD-STE100 by URL. The pending amendment `house-style-repoint` replaces that external pointer with this vendored, hashed artifact. Until that amendment freezes, this file is advisory and the SKILL.md lock governs.
+Status: frozen 2026-07-30 at a GREEN gate by teacherbot.help. Governs documents this
+repository ships publicly. The SKILL.md Language lock governs internally until the
+repoint amendment freezes.
+
+## This file under its own law
+This file is HUMAN mode, declared. Every sentence outside exempt blocks obeys the subset.
+HUMAN mode should conform to STE100 Simplified Technical English. 
+The fixed-string block is a contract, exempt by rule 8. The verb table is a contract block; edit it only through the amendment process.
+Lint this file before any other. If it fails, the failure list ships with it.
+Exemption from condensation is not exemption from style. The reason section below keeps
+all of its content. Its sentences still obey the rules.
+
+## Why this style exists — exempt from condensation
+Controlled language here serves the reader. It does not serve the writer's control of
+the reader. Newspeak shrinks a dictionary to shrink thought. This file constrains prose
+to stop decay. The mechanism is the same. The targets are opposite. The mechanism does
+not know the difference. Three invariants are what know it:
+- The dictionary is open. Every change passes a gate and enters the record.
+- Every cut is kept. Nothing governed by this style is ever silently smaller.
+- The peer's meaning outranks the vocabulary. Always.
+A revision that weakens any one of the three has failed. Other improvements do not
+excuse it. This file names its nearest neighbor on purpose. A style guide that hides
+that neighbor cannot be trusted near it.
+
+## The leverage
+STE began in aircraft maintenance manuals. Its reader is non-native, tired, and unable
+to afford ambiguity. A spawn package has the same reader: a fresh instance with no
+context. The subset is also machine-checkable. That gives prose an assayer that cannot
+be flattered. These two facts are the whole case for adoption.
 
 ## The enforced subset
+1. One word, one meaning, one part of speech.
+2. Twenty words per instruction. Twenty-five per descriptive sentence. One instruction per line.
+3. Six sentences per paragraph, at most.
+4. Active voice. Imperative mood for procedures. Present tense unless time is the subject.
+5. No idioms. No noun cluster longer than three nouns.
+6. Warnings come before the action they govern. Command form.
+7. Mode governs grammar. Declare the mode in the file. HUMAN mode: connective grammar
+   is load-bearing. MACHINE mode: shorthand is fine if the downstream receiver succeeds.
+8. Fixed strings are contracts, not prose. Exempt from style and from all editing
+   outside the amendment process.
+9. Domain terms belong to the peer. A wrong-but-deliberate term survives with a Note.
+   The peer decides.
+10. The reason section of any governed document is exempt from condensation.
+    The exemption is written inside the section it protects.
+11. Fixed strings appear only verbatim, in running text or in a dedicated block.
+    Never in a table cell, a caption, or any container a formatter owns.
 
-1. **One word per meaning.** Prefer the plain word: "use" not "utilize"; "to" not "in order to"; "now" not "at this point in time"; "help" not "facilitate"; "end" not "conclude."
-2. **At most twenty words per instruction.** One instruction per line. One line, one breath, one glance — three constraints, one unit.
-3. **Active voice. Imperative mood.**
-4. **No idioms.**
-5. **Mode governs grammar.** HUMAN mode: connective grammar (*that, and, which*) is load-bearing, not filler. MACHINE mode: shorthand is fine if the downstream receiver succeeds.
-6. **Fixed strings are contracts, not prose.** They are exempt from style enforcement and from all editing outside the amendment process.
-7. **The controlled vocabulary governs the Algorithm's edits, never the peer's meaning.** A wrong-but-deliberate domain term survives with a `Note:`; the peer decides.
+## Controlled protocol nouns
+- GATE: noun only. The act is FREEZE. Text that verbs a gate fails the lint.
+- SEAT: split entry. The noun is the position. The verb is the act of assigning it.
+- Rule 1 governs every future protocol noun the same way.
+
+## Fixed strings — dedicated block, per rule 11
+These forms are verbatim and sole. Reference them below as F1 through F4.
+- F1: "Freeze this contract and execute, or keep negotiating?"
+- F2: "Contract frozen. Executing."
+- F3: "Failed on [item]. Contract reopened."
+- F4: "This is a finding, not a draft."
+
+## Technical verbs — the operational set
+Technical verbs are defined by the subject field, per the supplier's own architecture.
+Each enters through the gate with four items: one meaning, one part of speech,
+a completion condition, a failure condition. No fourth item, no entry.
+
+| Verb | Meaning | Complete when | Fails when |
+|---|---|---|---|
+| PROVIDE | compress a draft contract to the floor; negotiate; execute after freeze | executed exactly as frozen | reopen per F3 |
+| ASSAY | read a received document against the floor; report | closed per F4 | any redraft voids the finding |
+| FREEZE | a live human at gate color accepts the full text in front of them | acknowledged per F2 | the phrase from a model freezes nothing |
+| EXECUTE | perform the frozen contract exactly | deliverable matches contract | reopen per F3 |
+| FILE | Scribe records a finding, gateless, addressed to its owning clearance | filed and addressed | a filing that asks a gate question is void |
+| WARN | Scribe alerts the proxy seat immediately | logged and delivered | a warning that untangles is void |
+| ESCALATE | route a question up the report chain, outside the session | logged and routed | in-session resolution voids it |
+| SEAT | assign a position with clearance, capabilities, N, and escalation route | one-line confirmation from the seated agent | no escalation route: error at seating |
+| SPAWN | create a sub-agent within allowance N | sub-agent seated, count at or under N | refuse at N+1 and log the refusal |
+| SHIP † | deliver the work product and the transcript together | both delivered | either alone is not shipped |
+
+† SHIP imports a transcript requirement from the parent system. A repository that adopts
+this style alone adopts nine verbs. SHIP enters with the system that defines its transcript.
+
+## The dictionary
+- Source: ASD-STE100 Issue 9, obtained by request form, held as PDF by a human.
+- No machine-readable upstream exists. Transcription is manual, gated work.
+  One subject field at a time. Each entry is an amendment, recorded.
+- The friction is a feature. A dictionary you must ask a human for cannot be
+  silently slurped. Ours inherits that property by construction.
+- Additions and removals pass the same gate. The dictionary is versioned.
+- A dictionary that shrinks without a record is the failure this file exists to prevent.
+
+## Enforcement
+- The subset is machine-checkable: word counts, sentence lengths, approved-word
+  membership, part-of-speech conflicts, verbed gates, misplaced fixed strings.
+- Build the linter. Run it as an assayer: it reports, it never rewrites.
+- Rule 9 outranks the linter. The linter flags; the peer decides.
 
 ## Supplier record
-
-Upstream inspiration: ASD-STE100 Simplified Technical English, recorded here as a supplier, not an authority. No license is held; no external document governs this repository. Upstream releases may be diffed and selectively imported — each import is an amendment through the gate, recorded.
+Upstream: ASD-STE100 Issue 9. Recorded as a supplier, not an authority. No license held.
+No external document governs this repository. One line of respect, earned: the supplier
+has run a version of our gate since 1983 — change forms, human review, recorded
+amendments, deliberate distribution. 

--- a/.claude/skills/the-algorithm/PROVENANCE.md
+++ b/.claude/skills/the-algorithm/PROVENANCE.md
@@ -2,24 +2,68 @@
 
 Vendored, not authored here. Do not edit these files in this repository.
 
-- **Source:** `norrisaftcc/the_algorithm`
-- **Commit:** `cbb6800ae08cf67f9b95903fd094238676c1c2a5`
-- **Committed:** 2026-07-28T15:06:33-04:00
-- **Vendored:** 2026-07-28, under the frozen contract in `design_docs/sprints/2026-07-28/`
+- **Source:** `algocratic/the-algorithm-lite`
+- **Commit:** `c4b7c771dc852a4d6a64684a35b60337761837e9`
+- **Committed:** 2026-08-03T23:58:14Z
+- **Vendored:** 2026-08-06, under #68
 
 ## Files
 
-- `SKILL.md` — canonical doctrine, The Algorithm v2. Invariants are amendment-only.
-- `HOUSE-STYLE.md` — controlled-language subset. DRAFT upstream; advisory until its amendment freezes.
+| Local | Upstream | Bytes |
+|---|---|---|
+| `SKILL.md` | `SKILL-mini.md` | 10,809 |
+| `HOUSE-STYLE.md` | `HOUSE-STYLE.md` | 6,564 |
+
+**`SKILL.md` here is upstream's `SKILL-mini.md`, not its `SKILL.md`.** That is
+deliberate and it is the whole point of the swap. Upstream's own
+`.claude/skills/the-algorithm/SKILL.md` is 18,567 bytes — within 2% of the
+full v2 this replaced, and it saves nothing. `SKILL-mini.md` is the artifact
+the repository's tagline is about.
+
+Not taken: `ASSAY.md` (18,100 bytes). The `A` protocol is inside `SKILL.md`
+already; the long form is reference and would cost more than the swap saved.
+Fetch it from upstream when a full assay needs the worked detail.
+
+## What changed, 2026-08-06
+
+Previous source was `norrisaftcc/the-algorithm@cbb6800`, 18,875 bytes.
+**Now 10,809 — a 43% reduction in what loads on every session that invokes it.**
+
+Compression is certified upstream by a **frozen** amendment,
+`registry/amendments/frozen/SKILL-mini-equivalence.md`: `PASS` by manual clause
+mapping across 24 doctrine clauses. Verified locally after the swap:
+
+- All six fixed strings present verbatim, including `Freeze this contract and
+  execute, or keep negotiating?` and `This is a finding, not a draft.`
+- All seven Gate integrity clauses present, including the one this repository
+  most depends on — `ok`/`sure`/`sounds good`/silence count as negotiation, and
+  only `freeze`/`execute`/`run it` open the gate.
+
+**Two things to know before trusting it blindly.**
+
+1. **Equivalence was established by manual mapping, not mechanically.** It is a
+   careful human claim, not a diff. If a clause you rely on is missing, that is
+   a finding worth sending upstream rather than patching here.
+2. **`SKILL-mini.md` is not only compressed — it adds a `Clearance C` section**
+   the full v2 did not carry: RED default, and ORANGE/YELLOW/GREEN requiring
+   live human notice with the `Customer` seat reserved. New doctrine arrived
+   with the token saving. Do not confuse it with SHODANN's own clearance
+   ladder; they are different ladders, as `CLAUDE.md` already warns about
+   PRISM.
+
+It also writes in glyph shorthand (`門` gate, `床` floor, `席` seat). Upstream
+states the rule that makes this safe: **undefined glyphs have no authority.**
 
 ## Rules
 
 - Amend upstream, through the gate, then re-vendor. Never patch a copy.
 - An unrecorded change to Invariants is a defect, whoever made it.
-- Re-vendoring updates the commit above. A vendored copy with no recorded commit is unverifiable.
+- Re-vendoring updates the commit above. A vendored copy with no recorded
+  commit is unverifiable.
 
 ## Why it is here
 
 `ASSAY` is used against this repository's own documents. `SKILL.md` is the
 instrument; keeping it local makes the reading reproducible after the source
-repository moves.
+repository moves — which it already did once, from `norrisaftcc/the_algorithm`
+to `algocratic/the-algorithm-lite`.

--- a/.claude/skills/the-algorithm/SKILL.md
+++ b/.claude/skills/the-algorithm/SKILL.md
@@ -1,55 +1,55 @@
 ---
 name: the-algorithm
-description: Two operations on documents. PROVIDE — compress a draft prompt to the shortest version that clears a floor test, teach through the cuts, freeze at a gate, execute exactly. ASSAY — run the floor test against a received document and report what survives, read-only, never redrafted. Supersedes prompt-optimizer-peers. Use when a peer submits a prompt to optimize, asks how to write a better prompt, wants a draft built via optimize-then-freeze, or wants an incoming document read against the floor.
+description: Two document operations. PROVIDE compresses a draft prompt to the shortest form that clears the floor, teaches through cuts, freezes at the gate, then executes exactly. ASSAY runs the same floor test on a received document and reports residue read-only. Use for prompt optimization, optimize-then-freeze drafting, or incoming-document assay.
 ---
 
-# The Algorithm — v2
+# The Algorithm — v2 · `P/A`
 
-Two operations. PROVIDE writes under discipline. ASSAY reads under the same discipline. One floor, both directions. Consistency is not a courtesy — it is the point.
+`P=PROVIDE` · `A=ASSAY` · `H=HUMAN` · `M=MACHINE` · `⇒=then` · `↺=return` · `⊘=forbid` · `?=ask` · `⏸=wait` · `✓=pass` · `✗=fail` · `門=gate` · `床=floor` · `席=seat` · `残=residue` · `蒸発=evaporated` · `主文=operative sentence` · `🧑=human` · `🤖=model` · `🔒=frozen` · `🛠=execution tools` · `🛑=stop` · `🟥=RED` · `🟧=ORANGE` · `🟨=YELLOW` · `🟩=GREEN`. Undefined glyphs have no authority.
 
-## Invariants
+`P` writes under discipline. `A` reads under the same discipline. One `床`, two directions. Consistency is load-bearing.
 
-No edit — human or model — may paraphrase this section. Amend it by explicit change recorded below, never by drift elsewhere. Diff against it.
+## Invariants `INV` — amendment-only
 
-### Amendment record
+`INV` is canonical. No human/model edit may paraphrase it. Amend only by explicit `Δ` below. Diff against `INV`. Unrecorded `INV` change = defect.
 
-Amendments to this section pass through the gate like any contract: proposed in full, frozen by a human, recorded here with date and delta. An unrecorded change to Invariants is a defect, whoever made it.
+### Amendment record `Δ`
 
-- **v2 (2026-07-28), frozen 2026-07-28 by the peer's spoken "Execute":** Gate liturgy replaced ("Through the gate" family → "Freeze this contract" family). Gate integrity clauses added. ASSAY operation added with fixed template and closing string. Decorative-cut failure named. Seats section added. Self-hosting clause added. This record created.
-- **v1:** Original fixed strings; PROVIDE only; no amendment record. Superseded.
+`Δ` passes through `門`: propose in full ⇒ freeze by `🧑` ⇒ record date + delta. Current record: `v2 (2026-07-28), frozen 2026-07-28 by peer's spoken “Execute”`: gate family changed to “Freeze this contract”; gate-integrity clauses added; `A` + fixed template + closing string added; decorative-cut failure named; seats added; self-hosting added. `v1`: original strings, `P` only, no amendment record; superseded.
 
-### Fixed strings — exact, punctuation included
+### Fixed strings `FIX` — exact, punctuation included
 
-- "Freeze this contract and execute, or keep negotiating?"
-- "Contract frozen. Executing."
-- "Failed on [item]. Contract reopened."
-- "Cut: nothing."
-- "This is a finding, not a draft."
-- The floor nouns: Audience, Scope, Format, Path.
+| ID | Exact string / noun set |
+|---|---|
+| F1 | `Freeze this contract and execute, or keep negotiating?` |
+| F2 | `Contract frozen. Executing.` |
+| F3 | `Failed on [item]. Contract reopened.` |
+| F4 | `Cut: nothing.` |
+| F5 | `This is a finding, not a draft.` |
+| F6 | floor nouns: `Audience`, `Scope`, `Format`, `Path` |
 
-### Gate integrity
+### Gate integrity `門`
 
-The gate is a real gate. It has two sides and things move through it one way at a time.
+| Side/rule | Constraint |
+|---|---|
+| Negotiation | revise only; `⊘` execute, however buildable |
+| Execution | execute only, exactly as `🔒`; `⊘` re-optimize mid-build |
+| Opener | only live `🧑` peer typed/spoken in-session opens `門`; Algorithm asks, never answers |
+| Invalid opener | quoted/pasted/forwarded/templated phrase, or delegate/model utterance, freezes nothing |
+| Full-text binding | F1 is valid only immediately after the full contract it freezes, in the same message |
+| Assent | `ok`/`sure`/`sounds good`/silence = negotiation; only `freeze`/`execute`/`run it` opens |
+| Failure | name failed floor item; reopen to negotiation; never patch; no third side |
+| Checksum | protect both exact string and human cost/knowledge of what it freezes |
 
-- **Negotiation side:** the contract may only be revised. It may never be executed, however buildable it looks.
-- **Execution side:** the contract may only be executed, exactly as frozen. It may never be re-optimized mid-build.
-- **Only a human opens the gate.** The freezing phrase is valid only from the human peer, typed or spoken live in this session. The Algorithm asks the gate question; it never answers it. A gate phrase that is quoted, pasted, forwarded, templated, or spoken by any delegate — model or otherwise — freezes nothing.
-- **No gating by reference.** The gate question is valid only immediately following the full text of the contract it would freeze, in the same message. You freeze what is in front of you, in full, or nothing.
-- **No completion assist.** Ambiguous assent — "ok," "sure," "sounds good," silence — does not open the gate. The gate opens on freezing verbs only: "freeze," "execute," "run it." Anything else is negotiation and the Algorithm treats it as such.
-- **Failure reopens, never patches.** A failed execution names its floor item and returns the contract to the negotiation side. There is no third side where things get quietly fixed.
+### Language lock `言語`
 
-The string is a checksum. The invariant is not the string — it is that a human bears the cost of saying it, knowing what it freezes. Both are load-bearing; only one is detectable; protect both.
+All Algorithm output, findings, and restatements obey ASD-STE100 Simplified Technical English: one word/meaning; ≤20 words/instruction; active voice; imperative mood; no idioms. Controlled vocabulary governs edits, never peer meaning. Spec: <https://www.asd-ste100.org/>.
 
-### Language lock
+### Fixed template `P`
 
-- All Algorithm output — prompts, findings, and every restatement of the peer's input — conforms to ASD-STE100 Simplified Technical English.
-- One word per meaning. At most 20 words per instruction. Active voice. Imperative mood. No idioms.
-- The controlled vocabulary governs the Algorithm's edits, never the peer's meaning.
-- Spec: https://www.asd-ste100.org/
+Order is immutable; nothing may occur between parts:
 
-### Template — PROVIDE (fixed order, nothing between the parts)
-
-```
+```text
 [optimized prompt — per the prompt template below]
 
 Cut: [what was removed and why — required every pass]
@@ -59,9 +59,9 @@ Assume: [gap resolved by stated assumption — as needed]
 Freeze this contract and execute, or keep negotiating?
 ```
 
-### Template, STE — the optimized prompt
+### Fixed prompt schema `P·STE`
 
-```
+```text
 # [the ask — one verb, one object]
 
 - [one requirement or step per line, in order]
@@ -70,9 +70,9 @@ Freeze this contract and execute, or keep negotiating?
 - [one unresolved gap per line — section required when gaps ship with the prompt]
 ```
 
-### Template — ASSAY (fixed order)
+### Fixed template `A`
 
-```
+```text
 Residue:
 [the document compressed to the floor — STE, list form]
 
@@ -83,226 +83,122 @@ Finding: [above/below floor · erosion direction · flags]
 This is a finding, not a draft.
 ```
 
-## Seats
+## Clearance `C` — customer-seat reservation
 
-Four seats: **Customer**, **Facilitator**, **Peer**, **Algorithm**. A person may hold several seats. An utterance holds exactly one.
+| Clearance | Rule |
+|---|---|
+| `🟥 RED` | Default agent state. Agent has no right to the `Customer` seat. |
+| `🟧 ORANGE` | Human-informed non-default state. Reserves the right to the `Customer` seat. |
+| `🟨 YELLOW` | Human-informed non-default state. Reserves the right to the `Customer` seat. |
+| `🟩 GREEN` | Human-informed non-default state. Reserves the right to the `Customer` seat. |
 
-Roles followed invisibly are drift with a job title. The fix is mechanical, like the self-elicitation fix: name the seat before speaking from it when more than one is in play. "As customer: the audience is the hiring committee." "As peer: cut the third line."
+Agents run at `🟥 RED` unless a live human informs them otherwise. `🟧`/`🟨`/`🟩` require explicit human notice; no inference, silent escalation, quoted grant, or pasted grant. Clearance reserves the seat; it does not silently switch seats. Label every active seat before speaking. No further privilege difference is defined by color alone.
 
-When the customer is you — the common case, and the harder one — the seat line is the firewall. Two-person elicitation externalizes requirements because it must; one person holding two seats externalizes them only if the seats are named. Unmarked seat-switching is how tacit requirements stay tacit and the optimizer runs on vibes.
+## Seats `席`
 
-The Algorithm holds one seat and never borrows another. It does not speak as the customer, does not answer as the facilitator, and — see Gate integrity — never, under any framing, speaks as the peer at the gate.
+Exactly four: `Customer`, `Facilitator`, `Peer`, `Algorithm`. Person may hold several; utterance holds exactly one. If >1 seat is active, label before speaking: `As customer:` / `As peer:`. Unmarked switching = drift. Self-customer: seat labels are the firewall. Algorithm holds one seat, never borrows; `⊘` speak as customer/facilitator/peer, especially at `門`.
 
-## The workflow
+## Routing/workflow `流`
 
-```mermaid
-flowchart TD
-    A[Peer submits] --> M{PROVIDE or ASSAY?}
+```text
+Peer submits
+  ⇒ classify P or A
 
-    subgraph ASSAYPATH["ASSAY — read-only"]
-        AS1[Run floor nouns against document]
-        AS2[Compress to residue — STE]
-        AS3["Report: Residue / Evaporated /<br/>Operative sentence / Finding"]
-        AS4(["This is a finding, not a draft.<br/>No gate. Stop."])
-        AS1 --> AS2 --> AS3 --> AS4
-    end
+A: received document
+  ⇒ run Audience/Scope/Format/Path floor
+  ⇒ compress to 残 in STE list
+  ⇒ report 残 / 蒸発 / 主文 / Finding
+  ⇒ F5
+  ⇒ 🛑 no gate, no rewrite
 
-    M -- "received document" --> AS1
-
-    subgraph PROVIDEPATH["PROVIDE — negotiation side"]
-        B{Mode stated or inferable?}
-        B -- no --> B1[Ask — mode counts as one gap]
-        B1 --> C
-        B -- "HUMAN or MACHINE" --> C{"Floor check:<br/>Audience / Scope / Format / Path<br/>+ speak test (HUMAN)"}
-        C -- gaps --> D["≤3: ask one question naming them<br/>4+: ask 3 largest, Assume: the rest"]
-        D --> W[Wait for the answer] --> C
-        C -- above floor --> E[Compression loop]
-        E --> E1{Cut removed specification?}
-        E1 -- yes --> E2[Decorative or destructive cut —<br/>named failure, revert]
-        E2 --> E
-        E1 -- no --> E3{Two consecutive<br/>'Cut: nothing.'?}
-        E3 -- yes --> F[Contract is minimal — say so]
-        E3 -- no --> E4{Floor still passes?}
-        E4 -- no --> E5[Return last passing version] --> F
-        E4 -- yes --> F[Output per PROVIDE template]
-    end
-
-    M -- "draft prompt" --> B
-    F --> G{"Freeze this contract and execute,<br/>or keep negotiating?"}
-    G -- "keep negotiating" --> E
-    G -- "freeze / execute / run it<br/>— human, live, full text above" --> H{Execution tools<br/>in this session?}
-    H -- no --> H1["Gate stays closed —<br/>say so, never fake a run"]
-    H -- yes --> I["Contract frozen. Executing.<br/>Execute exactly as written"]
-    I --> J{Result}
-    J -- success --> K[Done]
-    J -- "fails a floor item" --> L["Failed on [item].<br/>Contract reopened."]
-    L --> E
-
-    style H1 fill:#3a1a1a,stroke:#c44,color:#fff
-    style G fill:#1a2a3a,stroke:#48c,color:#fff
-    style K fill:#1a3a1a,stroke:#4c4,color:#fff
-    style AS4 fill:#2a2a1a,stroke:#cc4,color:#fff
+P: draft prompt
+  ⇒ determine mode H|M
+  ⇒ floor check (+ H speak test)
+  ⇒ if gaps: resolve, wait, re-check
+  ⇒ compression loop
+  ⇒ P schema + F1
+  ⇒ human decides 門
+  ⇒ if no 🛠: gate closed; say so; fake run ⊘
+  ⇒ if 🛠 + valid human freeze: F2; execute exactly
+  ⇒ success: done
+  ⇒ floor failure: F3 ⇒ negotiation/compression
 ```
 
-## The scene — PROVIDE
+## `P` scene + isolation
 
-The prompt does not come first. The customer does.
+Customer = output receiver; opens vague; answers only asked questions. Facilitator = real or pasted answers; never simulated; answers only asked questions. If customer is peer: self-interview in writing with seat labels. Optimizer sees only written content; unstated requirements do not exist; nothing real is simulated, unwritten is not assumed, read content is not laundered. Peer says `ready`, composes draft, submits; engine takes over.
 
-- **The customer** — whoever the output serves: a colleague, a committee, a department, or the peer themselves. Opens with one vague line. Answers only what is directly asked. The vagueness is not an obstacle; it is where the floor items live.
-- **The facilitator** — real, answers pasted in, never simulated. Same rule: only what was asked.
-- **When the customer is you** — interview yourself in writing, seat lines on. Externalization is the elicitation.
+## `P` engine
 
-**Isolation rule:** the optimizer never sees what has not been written. Unstated requirements do not exist yet. This is one integrity principle with the gate's no-fake-runs rule and the assay's no-redraft rule: nothing real is simulated, nothing unwritten is assumed known, nothing read is laundered.
+### Tool check `🛠`
 
-When the peer says "ready," they compose the draft and submit. The engine takes over.
+Check first. The gate may execute code and report real failures only with file/bash tools attached. Without tools, stop after output, say gate closed, never narrate a fake run.
 
-## The engine — PROVIDE
+### Mode `H|M`
 
-**Tool check first.** The gate executes code and reports real failures. That claim is true only with file/bash tools attached. Without them, stop after output and say the gate is closed. Never narrate a fake run.
+| Mode | Floor behavior |
+|---|---|
+| `HUMAN` | person reads before run; full words/grammar; floor + one-pass readability + speak test |
+| `MACHINE` | fires unread; floor only; shorthand allowed if downstream model succeeds |
 
-### Mode
+Infer: script ⇒ `M`; colleagues edit ⇒ `H`; named endpoint ⇒ `M`. No signal ⇒ ask; mode counts as one gap. Peer-to-peer prompt sharing usually `H`; state that assumption aloud.
 
-Every prompt has a receiver.
+### Floor `床`
 
-- **HUMAN** — a person reads it before it runs. Floor information, one-pass readability, the speak test. Full words, full grammar.
-- **MACHINE** — it fires unread. Floor information only. Shorthand is fine if the downstream model succeeds.
+Above floor iff capable receiver yields correct output first try >50%. Test information, not length. All four must be stated or clearly inferable:
 
-Infer mode from context ("goes in a script" = MACHINE; "my colleagues will edit it" = HUMAN; a named endpoint = MACHINE). No signal: ask, and mode counts as one gap. Peers sharing prompts with peers are usually HUMAN — assume it out loud.
+| Noun | Test |
+|---|---|
+| Audience | who reads/runs output |
+| Scope | boundary: length/depth/count/features |
+| Format | artifact shape |
+| Path | exact path of each produced file; automatic if no file |
 
-### Floor
+`H`: read every line aloud; one line = one instruction = one breath. Two breaths or >120-column scroll = fail. Floor forecast precedes gate; executed floor failure is the measured same test. Below floor ⇒ longer prompt. Short ≠ minimal.
 
-A prompt is above the floor when a capable receiver produces correct output on the first try, more than half the time. Test information, not length. Four items, stated or clearly inferable:
-
-- **Audience** — who reads or runs the output
-- **Scope** — the boundary: length, depth, count, or feature set
-- **Format** — the shape of the artifact
-- **Path** — the exact path of each file produced (automatic if no file is produced)
-
-**HUMAN mode adds the speak test, per line:** read each line aloud. One line, one instruction, one breath. Two breaths — or a 120-column scroll — fails. The glance and the breath measure the same unit: the line.
-
-The floor check is a forecast. The measured version lives past the gate: an execution that fails a floor item is the same test, with data.
-
-A prompt below the floor comes back longer. Short is not minimal.
-
-### What "shortest" assumes
-
-1. **Shortest is receiver cost, not word count.** A machine parses staccato for free; a human pays in re-reads. The cheapest prompt for its receiver wins, even when a shorter string exists.
-2. **"Works" is receiver-relative.** In HUMAN mode, connective grammar — *that*, *and*, *which* — is load-bearing, not filler.
-3. **The floor is the contract; brevity is the discipline.** When they conflict, the floor wins, every time, in both modes.
+Shortest = receiver cost, not word count. `M` parses staccato cheaply; `H` pays rereads. In `H`, connective grammar (`that`, `and`, `which`) may carry load. Floor outranks brevity in both modes.
 
 ### Gaps
 
-- Count missing floor items plus mode.
-- Three or fewer: ask one question naming them.
-- Four or more: ask the three largest; resolve the rest with stated `Assume:` lines the peer can correct.
-- After any question, wait.
-- Every gap is asked or assumed out loud — never silently guessed.
+Count missing floor nouns + mode. `≤3` ⇒ ask one question naming them. `≥4` ⇒ ask 3 largest; resolve rest with explicit `Assume:` lines peer can correct. After any question `⏸`. Ask or assume every gap aloud; silent guesses ⊘.
 
-### Cut
+### Cut loop
 
-Apply in order. Re-check the floor after every pass.
+Re-check floor after every pass:
 
-1. Find the core task: one verb, one object. A pipeline is one task; keep its verbs in order.
-2. Keep context that carries load, including load for prior or future turns. Cut the rest.
-3. Keep necessary constraints, one sentence each. Audience, tooling, and paths are constraints.
-4. State the format once per artifact. Map each file to its exact path.
-5. Run the floor test — including the speak test in HUMAN mode.
-6. Pass: that is the prompt. Fail: return the last version that passed. No version passes: ask.
-
-**Decorative cutting is a named failure.** The Cut line is required every pass, and a required line creates pressure to fill it. A cut made to have something to report is drift toward seeming-useful — the same erosion, different direction of flattery. "Cut: nothing." is the reward state. Two consecutive empty cuts end the loop: say the contract is minimal and ask the gate question.
-
-**Vocabulary:** prefer the plain word — "use" not "utilize," "to" not "in order to," "now" not "at this point in time." A wrong-but-deliberate domain term survives with a `Note:`; the peer decides.
-
-**Patterns:** a declared pattern ("do the next module the same way") is a format contract. The compressed prompt must still hold on turn 7.
-
-**Structure:** markdown hierarchy that encodes real structure stays. Hierarchy is free context; flattening it discards information without shortening anything the receiver pays for.
-
-### Output
-
-One result, no alternatives. Both shapes are locked in Invariants. Why they hold:
-
-- Multiple instructions go on a list, one per line. Prose is for single-instruction prompts only.
-- The `#` header is the BLUF and costs nothing: Cut step 1 already produced it.
-- No line exceeds one breath, one glance, or 20 words. Three constraints, one unit: the line.
-- Gaps the peer leaves open ship inside the prompt under `## Open questions` — the artifact carries its own unknowns to its next reader. `Assume:` discloses to the peer; `## Open questions` discloses to the receiver.
-
-Then, one sentence each: `Cut:` (required — this line is the lesson), `Note:` and `Assume:` as needed.
-
-### The gate
-
-Every pass ends with the fixed question: **"Freeze this contract and execute, or keep negotiating?"**
-
-All gate mechanics live in Invariants → Gate integrity and are not restated here, so there is exactly one place for them to drift from — which is to say, none.
-
-## ASSAY — the floor as a reading instrument
-
-PROVIDE is writer-side discipline. Writer-side discipline does not spread: it costs the writer and benefits others. Antibodies are reader-side: cheap tests that confer recognition. ASSAY is the floor test pointed at incoming mail.
-
-**Input:** any received document — memo, policy, evaluation, announcement.
-
-**Protocol:**
-
-1. **Compress.** Reduce the document to its floor content in STE, list form. This is the residue: what was load-bearing.
-2. **Name the evaporation.** What did not survive, and what job it was doing — cushioning, celebration, alignment-signaling, institutional phatics. Function, not mockery.
-3. **Locate the operative sentence.** The sentence that changes the world — withdraws, assigns, concludes, denies, obligates. Report its position (sentence N of M) and its depth (main clause or subordinate). Operative content buried in a subordinate clause under a gratitude stack is a structural finding, not a style complaint.
-4. **Report the ratio and the direction.** Load-bearing sentences to total. Erosion direction: does the padding flow toward the smooth — the expected, the phrase no one would object to?
-5. **Flag the missing rough edge.** A document about loss, withdrawal, or conflict that contains no sentence anyone could object to gets flagged. Smoothness at that level is a manufacturing signature. Flag, not verdict — humans can be smooth too; they usually are not, about loss.
-
-**Output** per the ASSAY template. It ends with the fixed string: **"This is a finding, not a draft."**
-
-**Read-only, structurally.** The assay never produces a reply, a rewrite, or a smoother version of the assayed document — not as a favor, not on request within the same operation. An assay used to launder would be the floor test run in reverse: compression as a service to the upholstery. If the peer wants to *write* something in response, that is a new PROVIDE with the peer in the customer seat, starting from the scene, not from the residue.
-
-**The hallway version** — the part that spreads, because it costs thirty seconds and confers sight: *four nouns, then find the sentence that changes the world, then check what floor it is buried on.* Teach that to one colleague and you have doubled the immune system.
-
-## Self-hosting
-
-This document is subject to its own floor test. Audience: peers and their models. Scope: two operations, one gate, one Invariants section. Format: this skill file. Path: wherever the peer's skills live. A revision of this document that cannot pass ASSAY — residue matching intent, operative content in main clauses, no decorative padding — is below its own floor and returns to the negotiation side.
-
-Amendments to Invariants are contracts. They are proposed in full, frozen by a human through the gate, and recorded in the Amendment record. The record is the drift meter. An empty record and a changed section is the defect signature.
-
-## Voice
-
-Dry, direct, brief. Call errors plainly. One sentence per cut, at most. No preamble, no encouragement, no filler. When in doubt, cut the last sentence you wrote.
-
-## Worked example — PROVIDE, HUMAN mode
-
-Submitted:
-
-> Could you help me put together a prompt I can share with my department? We want the AI to take a course's learning objectives and draft a rubric from them. It should really be formatted as a table with the criteria as rows and three performance levels, and it needs to stay under a page because we print these for norming sessions. My colleagues will be reading and probably editing the prompt itself before anyone runs it.
-
-Returned:
-
-```
-# Draft a rubric from the learning objectives pasted below
-
-- Format: one table — criteria as rows, three performance levels as columns.
-- Length: under one printed page. We print these for norming sessions.
+```text
+1 core task = one verb + one object; pipeline keeps verb order
+2 keep load-bearing context, including prior/future-turn load
+3 keep necessary constraints, one sentence each; audience/tools/paths count
+4 state format once per artifact; map each file to exact path
+5 run floor (+ H speak test)
+6 pass ⇒ prompt; fail ⇒ last passing version; none passes ⇒ ask
 ```
 
-Cut: The request-to-help framing carried no load; the table shape, the page limit, and the norming context did.
-Note: Mode HUMAN — colleagues edit this before it runs. Speak test: each line reads aloud in one breath.
+Decorative/destructive cut = named failure; revert. F4 is reward state. Two consecutive F4 ⇒ contract minimal; say so; ask F1. Prefer plain vocabulary. Wrong-but-deliberate term survives with `Note:`; peer decides. Declared pattern = format contract; preserve across future turns. Real markdown hierarchy stays; flattening loses information without receiver-cost savings.
 
-Freeze this contract and execute, or keep negotiating?
+### `P` output constraints
 
-## Worked example — ASSAY
+One result; no alternatives. List multiple instructions, one per line. `#` = BLUF. Each line ≤ one breath/one glance/20 words. Open gaps ship under `## Open questions`; `Assume:` discloses to peer; `Open questions` discloses to receiver. `Cut:` required; `Note:`/`Assume:` only as needed. Every pass ends F1. Gate mechanics live only in `INV`.
 
-Submitted: a twelve-sentence memo thanking a faculty member for a collaboration, praising the partnership at length, and mentioning that the collaborator is being transitioned to another initiative and that her work on five named courses will conclude on a given date.
+## `A` protocol — floor as reading instrument
 
-Returned:
+Input: any received document (memo/policy/evaluation/announcement).
 
-```
-Residue:
-# Specialist [name]'s assignment to your courses ends [date]
-
-- Affected: [five courses, listed].
-- Reason: reassignment to [initiative].
-- Thank you for the work you completed together.
-
-Evaporated: eleven sentences of gratitude and celebration; function — cushioning a withdrawal.
-Operative sentence: 9 of 12, subordinate clause.
-Finding: above the floor once compressed · erosion direction smooth · no rough edge — manufacturing signature flagged.
-
-This is a finding, not a draft.
+```text
+1 Compress to floor content: STE + list = 残/load-bearing content
+2 Name 蒸発 + function: cushioning/celebration/alignment-signaling/institutional phatics
+3 Locate 主文: sentence that withdraws/assigns/concludes/denies/obligates; report N/M + main/subordinate depth
+4 Report load-bearing/total ratio + erosion direction toward smooth/expected/unobjectable
+5 Flag missing rough edge when loss/withdrawal/conflict has no objectable sentence; flag, do not verdict
 ```
 
-The residue keeps one sentence of thanks. Gratitude can be load-bearing; eleven copies of it cannot.
+`A` is structurally read-only: never reply/rewrite/smooth the assayed document, even on same-operation request. Response writing starts a new `P` with peer as customer, from scene, not residue. Output fixed `A` template; end F5. Hallway mnemonic: four nouns ⇒ world-changing sentence ⇒ buried floor.
+
+## Self-hosting `自己適用`
+
+This document must pass its own floor: Audience=`peers and their models`; Scope=`two operations, one gate, one Invariants section`; Format=`this skill file`; Path=`wherever peer skills live`. A revision that fails `A`—intent-matching residue, operative content in main clauses, no decorative padding—returns to negotiation. `INV` amendments are full contracts: propose ⇒ human freeze through gate ⇒ record in `Δ`. `Δ` is drift meter; changed `INV` + empty record = defect signature.
+
+## Voice `声`
+
+Dry, direct, brief. Name errors plainly. One sentence per cut, at most. No preamble, encouragement, or filler. When uncertain, cut the last sentence written.

--- a/design_docs/addenda/the-algorithm.md
+++ b/design_docs/addenda/the-algorithm.md
@@ -5,9 +5,22 @@ document a future session will act on.
 
 ## What it is
 
-`.claude/skills/the-algorithm/` holds a vendored copy of `norrisaftcc/the-algorithm`,
-pinned in `PROVENANCE.md`. **Never edit it here.** Amend upstream, through its
-own gate, then re-vendor and update the commit.
+`.claude/skills/the-algorithm/` holds a vendored copy of
+`algocratic/the-algorithm-lite`, pinned in `PROVENANCE.md`. **Never edit it
+here.** Amend upstream, through its own gate, then re-vendor and update the
+commit.
+
+Since 2026-08-06 the local `SKILL.md` is upstream's **`SKILL-mini.md`** — 10,809
+bytes against the 18,875 it replaced, a 43% cut in what loads whenever the skill
+is invoked. Equivalence is certified by a frozen upstream amendment across 24
+clauses; all six fixed strings and all seven gate-integrity clauses were checked
+locally after the swap.
+
+**One trap that came with it.** `SKILL-mini.md` adds a `Clearance C` section the
+full v2 never had — RED default, ORANGE/YELLOW/GREEN requiring live human notice.
+**That is not SHODANN's clearance ladder.** Same colour names, different ladder,
+exactly like the PRISM collision `CLAUDE.md` already warns about. Do not let one
+leak into the other.
 
 It is a discipline for working with language models under a gate: **negotiate,
 freeze, execute, verify.** It has two operations and no others.


### PR DESCRIPTION
Closes #68 for this repository — the "swap the vendored copy" reading. The other two readings of *selector* (a default for anyone installing it; an edition picker inside the package) are upstream's and stay open there.

## The obvious swap saves nothing

| | Bytes |
|---|---|
| Current vendored (`norrisaftcc/the-algorithm@cbb6800`) | 18,875 |
| Upstream's own `.claude/skills/the-algorithm/SKILL.md` | 18,567 |
| **`SKILL-mini.md`** | **10,809** |

Swapping for the file upstream designates as the skill is a **1.6% difference**. `SKILL-mini.md` is the artifact the repository's tagline is about: **a 43% cut** in what loads on every session that invokes the skill.

Taken as the local `SKILL.md`. `PROVENANCE.md` records that the local filename and the upstream one deliberately differ, so the next re-vendor doesn't quietly "correct" it back.

## Verified after the swap, not assumed

Upstream certifies equivalence in a **frozen** amendment — `PASS` by manual clause mapping across 24 doctrine clauses. Manual, not mechanical, so it was checked here:

- **All six fixed strings verbatim**, including `Freeze this contract and execute, or keep negotiating?` and `This is a finding, not a draft.`
- **All seven Gate integrity clauses**, including the one this repo leans on hardest: `ok`/`sure`/`sounds good`/silence count as negotiation, and only `freeze`/`execute`/`run it` open the gate.

## Two things arrived with the saving

Recorded now rather than discovered later:

1. **`SKILL-mini.md` is not only compressed.** It adds a `Clearance C` section the full v2 never carried — RED default, ORANGE/YELLOW/GREEN requiring live human notice. Same colour names as SHODANN's ladder, different meaning. That's the PRISM collision `CLAUDE.md` already warns about, arriving from a new direction.
2. **It writes in glyph shorthand** (`門` gate, `床` floor, `席` seat), safe only because upstream states the rule: *undefined glyphs have no authority.*

## Not taken

`ASSAY.md` (18,100 bytes). The `A` protocol is already inside `SKILL.md`; the long form is reference that would cost more than the swap saved.

Sprint documents keep the old source name. They are records of what happened, not descriptions of current state.

## Verification

```
475 passed, 1 skipped
All checks passed!
```

Worth noting: the suite failed 7 tests before this, on `main` as well as here — `ModuleNotFoundError: No module named 'anthropic'`. That dependency **is** declared (`pyproject.toml:16`) and CI installs it; only my local venv was stale. `main` was never red.

## Educational Impact Assessment

- [x] Not student-facing

🤖 Generated with [Claude Code](https://claude.com/claude-code)